### PR TITLE
fix: `handle case where gokon returns nil for object`

### DIFF
--- a/kong/resource_kong_api.go
+++ b/kong/resource_kong_api.go
@@ -2,6 +2,7 @@ package kong
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/kevholditch/gokong"
 )
@@ -133,19 +134,24 @@ func resourceKongApiRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("could not find kong api: %v", err)
 	}
 
-	d.Set("name", api.Name)
-	d.Set("hosts", api.Hosts)
-	d.Set("uris", api.Uris)
-	d.Set("methods", api.Methods)
-	d.Set("upstream_url", api.UpstreamUrl)
-	d.Set("strip_uri", api.StripUri)
-	d.Set("preserve_host", api.PreserveHost)
-	d.Set("retries", api.Retries)
-	d.Set("upstream_connect_timeout", api.UpstreamConnectTimeout)
-	d.Set("upstream_send_timeout", api.UpstreamSendTimeout)
-	d.Set("upstream_read_timeout", api.UpstreamReadTimeout)
-	d.Set("https_only", api.HttpsOnly)
-	d.Set("http_if_terminated", api.HttpIfTerminated)
+	if api == nil {
+		d.SetId("")
+	} else {
+		d.Set("name", api.Name)
+		d.Set("hosts", api.Hosts)
+		d.Set("uris", api.Uris)
+		d.Set("methods", api.Methods)
+		d.Set("upstream_url", api.UpstreamUrl)
+		d.Set("strip_uri", api.StripUri)
+		d.Set("preserve_host", api.PreserveHost)
+		d.Set("retries", api.Retries)
+		d.Set("upstream_connect_timeout", api.UpstreamConnectTimeout)
+		d.Set("upstream_send_timeout", api.UpstreamSendTimeout)
+		d.Set("upstream_read_timeout", api.UpstreamReadTimeout)
+		d.Set("https_only", api.HttpsOnly)
+		d.Set("http_if_terminated", api.HttpIfTerminated)
+
+	}
 
 	return nil
 }

--- a/kong/resource_kong_certificate.go
+++ b/kong/resource_kong_certificate.go
@@ -2,6 +2,7 @@ package kong
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/kevholditch/gokong"
 )
@@ -68,8 +69,12 @@ func resourceKongCertificateRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("could not find kong certificate: %v", err)
 	}
 
-	d.Set("certificate", certificate.Cert)
-	d.Set("private_key", certificate.Key)
+	if certificate == nil {
+		d.SetId("")
+	} else {
+		d.Set("certificate", certificate.Cert)
+		d.Set("private_key", certificate.Key)
+	}
 
 	return nil
 }

--- a/kong/resource_kong_consumer.go
+++ b/kong/resource_kong_consumer.go
@@ -2,6 +2,7 @@ package kong
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/kevholditch/gokong"
 )
@@ -69,8 +70,12 @@ func resourceKongConsumerRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("could not find kong consumer with id: %s error: %v", id, err)
 	}
 
-	d.Set("username", consumer.Username)
-	d.Set("custom_id", consumer.CustomId)
+	if consumer == nil {
+		d.SetId("")
+	} else {
+		d.Set("username", consumer.Username)
+		d.Set("custom_id", consumer.CustomId)
+	}
 
 	return nil
 }

--- a/kong/resource_kong_plugin.go
+++ b/kong/resource_kong_plugin.go
@@ -2,6 +2,7 @@ package kong
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/kevholditch/gokong"
 )
@@ -76,7 +77,11 @@ func resourceKongPluginRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("could not find kong plugin: %v", err)
 	}
 
-	d.Set("name", plugin.Name)
+	if plugin == nil {
+		d.SetId("")
+	} else {
+		d.Set("name", plugin.Name)
+	}
 
 	return nil
 }

--- a/kong/resource_kong_sni.go
+++ b/kong/resource_kong_sni.go
@@ -2,6 +2,7 @@ package kong
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/kevholditch/gokong"
 )
@@ -53,8 +54,12 @@ func resourceKongSniRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("could not find kong sni: %v", err)
 	}
 
-	d.Set("name", sni.Name)
-	d.Set("certificate_id", sni.SslCertificateId)
+	if sni == nil {
+		d.SetId("")
+	} else {
+		d.Set("name", sni.Name)
+		d.Set("certificate_id", sni.SslCertificateId)
+	}
 
 	return nil
 }

--- a/kong/resource_kong_upstream.go
+++ b/kong/resource_kong_upstream.go
@@ -2,6 +2,7 @@ package kong
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/kevholditch/gokong"
 )
@@ -60,8 +61,12 @@ func resourceKongUpstreamRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("could not find kong upstream: %v", err)
 	}
 
-	d.Set("name", upstream.Name)
-	d.Set("slots", upstream.Slots)
+	if upstream == nil {
+		d.SetId("")
+	} else {
+		d.Set("name", upstream.Name)
+		d.Set("slots", upstream.Slots)
+	}
 
 	return nil
 }

--- a/vendor/github.com/kevholditch/gokong/README.md
+++ b/vendor/github.com/kevholditch/gokong/README.md
@@ -353,6 +353,24 @@ updatePluginRequest := &gokong.PluginRequest{
 
 updatedPlugin, err := gokong.NewClient(gokong.NewDefaultConfig()).Plugins().UpdateById("70692eed-2293-486d-b992-db44a6459360", updatePluginRequest)
 ```
+## Configure a plugin for a Consumer
+To configure a plugin for a consumer you can use the `CreatePluginConfig`, `GetPluginConfig` and `DeletePluginConfig` methods on the `Consumers` endpoint.
+  Some plugins require configuration for a consumer for example the [jwt plugin[(https://getkong.org/plugins/jwt/#create-a-jwt-credential).
+
+Create a plugin config for a consumer:
+```go
+createdPluginConfig, err := gokong.NewClient(gokong.NewDefaultConfig()).Consumers().CreatePluginConfig("f6539872-d8c5-4d6c-a2f2-923760329e4e", "jwt", "{\"key\": \"a36c3049b36249a3c9f8891cb127243c\"}")
+```
+
+Get a plugin config for a consumer by plugin config id:
+```
+pluginConfig, err := gokong.NewClient(gokong.NewDefaultConfig()).Consumers().GetPluginConfig("58c5229-dc92-4632-91c1-f34d9b84db0b", "jwt", "22700b52-ba59-428e-b03b-ba429b1e775e")
+```
+
+Delete a plugin config for a consumer by plugin config id:
+```
+err := gokong.NewClient(gokong.NewDefaultConfig()).Consumers().DeletePluginConfig("3958a860-ceac-4a6c-9bbb-ff8d69a585d2", "jwt", "bde04c3a-46bb-45c9-9006-e8af20d04342")
+```
 
 ## Certificates
 Create a Certificate ([for more information on the Certificate Fields see the Kong documentation](https://getkong.org/docs/0.11.x/admin-api/#certificate-object)):

--- a/vendor/github.com/kevholditch/gokong/consumers.go
+++ b/vendor/github.com/kevholditch/gokong/consumers.go
@@ -35,6 +35,11 @@ type ConsumerFilter struct {
 	Offset   int    `url:"offset,omitempty"`
 }
 
+type ConsumerPluginConfig struct {
+	Id   string `json:"id,omitempty"`
+	Body string
+}
+
 const ConsumersPath = "/consumers/"
 
 func (consumerClient *ConsumerClient) GetByUsername(username string) (*Consumer, error) {
@@ -143,4 +148,58 @@ func (consumerClient *ConsumerClient) UpdateById(id string, consumerRequest *Con
 	}
 
 	return updatedConsumer, nil
+}
+
+func (consumerClient *ConsumerClient) CreatePluginConfig(consumerId string, pluginName string, pluginConfig string) (*ConsumerPluginConfig, error) {
+
+	_, body, errs := gorequest.New().Post(consumerClient.config.HostAddress + ConsumersPath + consumerId + "/" + pluginName).Send(pluginConfig).End()
+	if errs != nil {
+		return nil, fmt.Errorf("could not configure plugin for consumer, error: %v", errs)
+	}
+
+	createdConsumerPluginConfig := &ConsumerPluginConfig{}
+	err := json.Unmarshal([]byte(body), createdConsumerPluginConfig)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse consumer plugin config created response, error: %v", err)
+	}
+
+	if createdConsumerPluginConfig.Id == "" {
+		return nil, fmt.Errorf("could not create consumer plugin config, error: %v", body)
+	}
+
+	createdConsumerPluginConfig.Body = body
+
+	return createdConsumerPluginConfig, nil
+}
+
+func (consumerClient *ConsumerClient) GetPluginConfig(consumerId string, pluginName string, id string) (*ConsumerPluginConfig, error) {
+
+	_, body, errs := gorequest.New().Get(consumerClient.config.HostAddress + ConsumersPath + consumerId + "/" + pluginName + "/" + id).End()
+	if errs != nil {
+		return nil, fmt.Errorf("could not get plugin config for consumer, error: %v", errs)
+	}
+
+	consumerPluginConfig := &ConsumerPluginConfig{}
+	err := json.Unmarshal([]byte(body), consumerPluginConfig)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse consumer plugin config response, error: %v", err)
+	}
+
+	if consumerPluginConfig.Id == "" {
+		return nil, fmt.Errorf("could not get consumer plugin config, error: %v", body)
+	}
+
+	consumerPluginConfig.Body = body
+
+	return consumerPluginConfig, nil
+}
+
+func (consumerClient *ConsumerClient) DeletePluginConfig(consumerId string, pluginName string, id string) error {
+
+	_, _, errs := gorequest.New().Delete(consumerClient.config.HostAddress + ConsumersPath + consumerId + "/" + pluginName + "/" + id).End()
+	if errs != nil {
+		return fmt.Errorf("could not delete plugin config for consumer, error: %v", errs)
+	}
+
+	return nil
 }

--- a/vendor/github.com/kevholditch/gokong/containers/kong_container.go
+++ b/vendor/github.com/kevholditch/gokong/containers/kong_container.go
@@ -56,7 +56,7 @@ func NewKongContainer(pool *dockertest.Pool, postgres *postgresContainer, kongVe
 
 	options = &dockertest.RunOptions{
 		Repository: "kong",
-		Tag:        "0.11",
+		Tag:        kongVersion,
 		Env:        envVars,
 		Links:      []string{fmt.Sprintf("%s:postgres", postgres.Name)},
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -535,10 +535,10 @@
 			"revisionTime": "2016-08-03T19:07:31Z"
 		},
 		{
-			"checksumSHA1": "HruEFOPQZN6CMYOKBbtdImsvyoM=",
+			"checksumSHA1": "sJ53HzA3JtsGtKxchdIDbLNYCvU=",
 			"path": "github.com/kevholditch/gokong",
-			"revision": "570a1ae398bf90e322918e409358685febc3d575",
-			"revisionTime": "2018-01-05T10:16:20Z"
+			"revision": "5198c6dcd03a0ef85466f08712ca15260fcc5586",
+			"revisionTime": "2018-02-01T19:46:06Z"
 		},
 		{
 			"path": "github.com/kevholditch/gokong...",


### PR DESCRIPTION
The gokong library has a case where it can return nil for both an error and an object.  If a user deletes a resource manually in Kong it causes this case.  This fix addresses that by informing terraform to re-create the resource that was deleted.  It does this by

```go
object.SetId("")
```
In each of the resource blocks.