### PR TITLE
Configure Plugin with Key/Value

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,23 @@ The example above shows configuring the jwt plugin for a consumer.
 `config_json` this is the configuration json for how you want to configure the plugin.  The json is passed straight through to kong as is.  You can get the json config from the Kong documentation
 page of the plugin you are configuring
 
+Other plugins must be configured using key/value pairs, for example the [acl](https://getkong.org/plugins/acl/) plugin.  To update a plugin using key value pairs configure the "kong_consumer_plugin_config" resource.
+
+```hcl
+resource "kong_consumer_plugin_config" "consumer_acl_config" {
+    consumer_id = "876bf719-8f18-4ce5-cc9f-5b5af6c36007"
+    plugin_name = "acls"
+    config      = {
+        group = "your_acl_group"
+    }
+}
+```
+
+All parameters are the same as above except the `config` parameter.
+`config` is a map of key/value pairs you wish to pass as the configuration.
+
+#### NOTE:  You can only have either config or config_json configured, not both.
+
 
 ## Consumers
 ```hcl

--- a/kong/resource_kong_consumer_plugin_config.go
+++ b/kong/resource_kong_consumer_plugin_config.go
@@ -30,6 +30,7 @@ func resourceKongConsumerPluginConfig() *schema.Resource {
 			},
 			"config": &schema.Schema{
 				Type:     schema.TypeMap,
+				ForceNew: true,
 				Optional: true,
 				Elem:     schema.TypeString,
 				Default:  nil,

--- a/kong/resource_kong_consumer_plugin_config.go
+++ b/kong/resource_kong_consumer_plugin_config.go
@@ -1,12 +1,14 @@
 package kong
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/kevholditch/gokong"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/kevholditch/gokong"
 )
 
 func resourceKongConsumerPluginConfig() *schema.Resource {
@@ -25,6 +27,12 @@ func resourceKongConsumerPluginConfig() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+			"config": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeString,
+				Default:  nil,
 			},
 			"config_json": &schema.Schema{
 				Type:         schema.TypeString,
@@ -92,14 +100,38 @@ func splitIdIntoFields(id string) (*idFields, error) {
 	}, nil
 }
 
+//Create either a key=value based list of parameters or json
+func generatePluginConfig(configMap map[string]interface{}, configJSON string) (string, error) {
+	if configMap != nil && configJSON != "" {
+		return "", fmt.Errorf("Cannot declare both config and config_json")
+	}
+	if configMap != nil {
+		var buffer bytes.Buffer
+		mapSize := len(configMap)
+		position := 1
+		for key, value := range configMap {
+			buffer.WriteString(key)
+			buffer.WriteString("=")
+			buffer.WriteString(value.(string))
+			if mapSize > 1 && position != mapSize {
+				buffer.WriteString("&")
+			}
+			position = position + 1
+		}
+		return buffer.String(), nil
+	}
+	return configJSON, nil
+}
+
 func resourceKongConsumerPluginConfigCreate(d *schema.ResourceData, meta interface{}) error {
 
 	consumerId := readStringFromResource(d, "consumer_id")
 	pluginName := readStringFromResource(d, "plugin_name")
-	config := readStringFromResource(d, "config_json")
-
+	config, err := generatePluginConfig(readMapFromResource(d, "config"), readStringFromResource(d, "config_json"))
+	if err != nil {
+		return fmt.Errorf("error configuring plugin: %v", err)
+	}
 	consumerPluginConfig, err := meta.(*gokong.KongAdminClient).Consumers().CreatePluginConfig(consumerId, pluginName, config)
-
 	if err != nil {
 		return fmt.Errorf("failed to create kong consumer plugin config, error: %v", err)
 	}

--- a/kong/resource_kong_consumer_plugin_config_test.go
+++ b/kong/resource_kong_consumer_plugin_config_test.go
@@ -176,6 +176,22 @@ EOT
 `
 
 const testCreateConsumerPluginConfigKV = `
+resource "kong_api" "api" {
+	name 	= "TestApi"
+  	hosts   = [ "example.com" ]
+	uris 	= [ "/example" ]
+	methods = [ "GET", "POST" ]
+	upstream_url = "http://localhost:4140"
+	strip_uri = false
+	preserve_host = false
+	retries = 3
+	upstream_connect_timeout = 60000
+	upstream_send_timeout = 30000
+	upstream_read_timeout = 10000
+	https_only = false
+	http_if_terminated = false
+}
+
 resource "kong_consumer" "my_consumer" {
 	username  = "User1"
 	custom_id = "123"
@@ -183,7 +199,8 @@ resource "kong_consumer" "my_consumer" {
 
 resource "kong_plugin" "acl_plugin" {
 	name        = "acl"	
-	config = {
+	api_id      = "${kong_api.api.id}"
+	config      = {
 		whitelist = "nginx"
 	}
 }
@@ -198,13 +215,30 @@ resource "kong_consumer_plugin_config" "consumer_acl_config" {
 `
 
 const testUpdateConsumerPluginConfigKV = `
+resource "kong_api" "api" {
+	name 	= "TestApi"
+  	hosts   = [ "example.com" ]
+	uris 	= [ "/example" ]
+	methods = [ "GET", "POST" ]
+	upstream_url = "http://localhost:4140"
+	strip_uri = false
+	preserve_host = false
+	retries = 3
+	upstream_connect_timeout = 60000
+	upstream_send_timeout = 30000
+	upstream_read_timeout = 10000
+	https_only = false
+	http_if_terminated = false
+}
+
 resource "kong_consumer" "my_consumer" {
 	username  = "User1"
 	custom_id = "123"
 }
 
 resource "kong_plugin" "acl_plugin" {
-	name        = "jwt"	
+	name        = "acl"	
+	api_id      = "${kong_api.api.id}"
 	config = {
 		whitelist = "apache"
 	}

--- a/kong/resource_kong_consumer_plugin_config_test.go
+++ b/kong/resource_kong_consumer_plugin_config_test.go
@@ -42,7 +42,7 @@ func TestAccKongConsumerPluginConfigKV(t *testing.T) {
 		CheckDestroy: testAccCheckKongConsumerPluginConfig,
 		Steps: []resource.TestStep{
 			{
-				Config: testCreateConsumerPluginConfig,
+				Config: testCreateConsumerPluginConfigKV,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKongConsumerPluginConfigExists("kong_consumer_plugin_config.consumer_jwt_config"),
 					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_jwt_config", "plugin_name", "jwt"),
@@ -50,7 +50,7 @@ func TestAccKongConsumerPluginConfigKV(t *testing.T) {
 				),
 			},
 			{
-				Config: testUpdateConsumerPluginConfig,
+				Config: testUpdateConsumerPluginConfigKV,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKongConsumerPluginConfigExists("kong_consumer_plugin_config.consumer_jwt_config"),
 					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_jwt_config", "plugin_name", "jwt"),
@@ -181,16 +181,16 @@ resource "kong_consumer" "my_consumer" {
 	custom_id = "123"
 }
 
-resource "kong_plugin" "jwt_plugin" {
-	name        = "jwt"	
-	config 		= {
-		claims_to_verify = "exp"
+resource "kong_plugin" "acl_plugin" {
+	name        = "acl"	
+	config = {
+		whitelist = "nginx"
 	}
 }
 
-resource "kong_consumer_plugin_config" "consumer_jwt_config" {
+resource "kong_consumer_plugin_config" "consumer_acl_config" {
 	consumer_id = "${kong_consumer.my_consumer.id}"
-	plugin_name = "jwt"
+	plugin_name = "acls"
 	config = {
 		group = "nginx"
 	}
@@ -203,16 +203,16 @@ resource "kong_consumer" "my_consumer" {
 	custom_id = "123"
 }
 
-resource "kong_plugin" "jwt_plugin" {
+resource "kong_plugin" "acl_plugin" {
 	name        = "jwt"	
-	config 		= {
-		claims_to_verify = "exp"
+	config = {
+		whitelist = "apache"
 	}
 }
 
-resource "kong_consumer_plugin_config" "consumer_jwt_config" {
+resource "kong_consumer_plugin_config" "consumer_acl_config" {
 	consumer_id = "${kong_consumer.my_consumer.id}"
-	plugin_name = "jwt"
+	plugin_name = "acls"
 	config      = {
 		group = "apache"
 	}

--- a/kong/resource_kong_consumer_plugin_config_test.go
+++ b/kong/resource_kong_consumer_plugin_config_test.go
@@ -44,17 +44,17 @@ func TestAccKongConsumerPluginConfigKV(t *testing.T) {
 			{
 				Config: testCreateConsumerPluginConfigKV,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKongConsumerPluginConfigExists("kong_consumer_plugin_config.consumer_jwt_config"),
-					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_jwt_config", "plugin_name", "jwt"),
-					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_jwt_config", "config.group", "nginx"),
+					testAccCheckKongConsumerPluginConfigExists("kong_consumer_plugin_config.consumer_acl_config"),
+					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_acl_config", "plugin_name", "acls"),
+					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_acl_config", "config.group", "nginx"),
 				),
 			},
 			{
 				Config: testUpdateConsumerPluginConfigKV,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKongConsumerPluginConfigExists("kong_consumer_plugin_config.consumer_jwt_config"),
-					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_jwt_config", "plugin_name", "jwt"),
-					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_jwt_config", "config.group", "apache"),
+					testAccCheckKongConsumerPluginConfigExists("kong_consumer_plugin_config.consumer_acl_config"),
+					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_acl_config", "plugin_name", "acls"),
+					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_acl_config", "config.group", "apache"),
 				),
 			},
 		},


### PR DESCRIPTION
I found a use case where a plugin doesn't take a JSON string as the data, but instead needs a Key/Value pair.  This adds the capability to configure a plugin with one or the other.  For instance the plugin below must be configured with key values to associate it with a consumer.

https://getkong.org/plugins/acl/?_ga=2.6015035.984149835.1517336615-2056304949.1516986557