### PR TITLE
Set CGO_ENABLED=0 to create statically linked binary

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,5 +1,7 @@
 builds:
   - binary: terraform-provider-kong_v{{.Version}}
+    env:
+      - CGO_ENABLED=0
     goos:
       - darwin
       - linux


### PR DESCRIPTION
This allows the provider to work on alpine-based docker images, such as the official terraform image.  See #25 for more info.