### PR TITLE
Support importing of plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+dist
 
 website/vendor
 

--- a/kong/resource_kong_consumer_plugin_config.go
+++ b/kong/resource_kong_consumer_plugin_config.go
@@ -17,6 +17,10 @@ func resourceKongConsumerPluginConfig() *schema.Resource {
 		Read:   resourceKongConsumerPluginConfigRead,
 		Delete: resourceKongConsumerPluginConfigDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"consumer_id": &schema.Schema{
 				Type:     schema.TypeString,

--- a/kong/resource_kong_plugin.go
+++ b/kong/resource_kong_plugin.go
@@ -14,6 +14,10 @@ func resourceKongPlugin() *schema.Resource {
 		Delete: resourceKongPluginDelete,
 		Update: resourceKongPluginUpdate,
 
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/kong/resource_kong_plugin_test.go
+++ b/kong/resource_kong_plugin_test.go
@@ -129,6 +129,25 @@ func TestAccKongPluginForASpecificApiAndConsumer(t *testing.T) {
 	})
 }
 
+func TestAccKongPluginImport(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKongPluginDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testImportPluginForASpecificApiConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      "kong_plugin.basic_auth",
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
 func testAccCheckKongPluginDestroy(state *terraform.State) error {
 
 	client := testAccProvider.Meta().(*gokong.KongAdminClient)
@@ -372,6 +391,32 @@ resource "kong_plugin" "rate_limit" {
 	consumer_id = "${kong_consumer.plugin_consumer.id}"
 	config 		= {
 		limits.sms.minute = 23
+	}
+}
+`
+
+const testImportPluginForASpecificApiConfig = `
+resource "kong_api" "api" {
+	name 	= "TestApi"
+  	hosts   = [ "example.com" ]
+	uris 	= [ "/example" ]
+	methods = [ "GET", "POST" ]
+	upstream_url = "http://localhost:4140"
+	strip_uri = false
+	preserve_host = false
+	retries = 3
+	upstream_connect_timeout = 60000
+	upstream_send_timeout = 30000
+	upstream_read_timeout = 10000
+	https_only = false
+	http_if_terminated = false
+}
+
+resource "kong_plugin" "basic_auth" {
+	name   = "basic-auth"
+	api_id = "${kong_api.api.id}"
+	config = {
+		hide_credentials = "false"
 	}
 }
 `


### PR DESCRIPTION
This allows you to import plugins and consumer plugin configs.

Due to the way that the `config` fields are managed by kong / the provider, the resulting state file does not currently include the config field.

However, it does include all of the other info, and allows you to run an apply against an already configured kong.  It simply will delete / recreate any existing plugins to have the same config as your TF configs.  So this is okay for an initial import to use this provider.

Without this, it will create new copies of the plugins, and leave any previously configured plugins around, which may conflict or cause other issues.

What would be better is if the `read` action in the plugin resources read the config in and called `d.Set("config", plugin.Config)` .. however I could not get this to work properly due to the dynamic nature of this field .. and especially with the `config` and `config_json` being split.