### PR TITLE
fix unauthorised requests

### DIFF
--- a/kong/resource_kong_api.go
+++ b/kong/resource_kong_api.go
@@ -102,7 +102,7 @@ func resourceKongApiCreate(d *schema.ResourceData, meta interface{}) error {
 
 	api, err := meta.(*gokong.KongAdminClient).Apis().Create(apiRequest)
 
-	if err != nil && api != nil {
+	if err != nil || api == nil {
 		return fmt.Errorf("failed to create kong api: %v error: %v", apiRequest, err)
 	}
 

--- a/vendor/github.com/kevholditch/gokong/apis.go
+++ b/vendor/github.com/kevholditch/gokong/apis.go
@@ -67,10 +67,14 @@ func (apiClient *ApiClient) GetByName(name string) (*Api, error) {
 }
 
 func (apiClient *ApiClient) GetById(id string) (*Api, error) {
-	_, body, errs := newGet(apiClient.config, apiClient.config.HostAddress+ApisPath+id).End()
+	r, body, errs := newGet(apiClient.config, apiClient.config.HostAddress+ApisPath+id).End()
 
 	if errs != nil {
 		return nil, fmt.Errorf("could not get api, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	api := &Api{}
@@ -98,9 +102,13 @@ func (apiClient *ApiClient) ListFiltered(filter *ApiFilter) (*Apis, error) {
 		return nil, fmt.Errorf("could not build query string for apis filter, error: %v", err)
 	}
 
-	_, body, errs := newGet(apiClient.config, address).End()
+	r, body, errs := newGet(apiClient.config, address).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get apis, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	apis := &Apis{}
@@ -114,9 +122,13 @@ func (apiClient *ApiClient) ListFiltered(filter *ApiFilter) (*Apis, error) {
 
 func (apiClient *ApiClient) Create(newApi *ApiRequest) (*Api, error) {
 
-	_, body, errs := newPost(apiClient.config, apiClient.config.HostAddress+ApisPath).Send(newApi).End()
+	r, body, errs := newPost(apiClient.config, apiClient.config.HostAddress+ApisPath).Send(newApi).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new api, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdApi := &Api{}
@@ -138,9 +150,13 @@ func (apiClient *ApiClient) DeleteByName(name string) error {
 
 func (apiClient *ApiClient) DeleteById(id string) error {
 
-	res, _, errs := newDelete(apiClient.config, apiClient.config.HostAddress+ApisPath+id).End()
+	r, body, errs := newDelete(apiClient.config, apiClient.config.HostAddress+ApisPath+id).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete api, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete api, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil
@@ -152,13 +168,13 @@ func (apiClient *ApiClient) UpdateByName(name string, apiRequest *ApiRequest) (*
 
 func (apiClient *ApiClient) UpdateById(id string, apiRequest *ApiRequest) (*Api, error) {
 
-	j, _ := json.Marshal(apiRequest)
-	js := string(j)
-	fmt.Sprintf("%s", js)
-
-	_, body, errs := newPatch(apiClient.config, apiClient.config.HostAddress+ApisPath+id).Send(apiRequest).End()
+	r, body, errs := newPatch(apiClient.config, apiClient.config.HostAddress+ApisPath+id).Send(apiRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update api, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedApi := &Api{}

--- a/vendor/github.com/kevholditch/gokong/certificates.go
+++ b/vendor/github.com/kevholditch/gokong/certificates.go
@@ -29,9 +29,13 @@ const CertificatesPath = "/certificates/"
 
 func (certificateClient *CertificateClient) GetById(id string) (*Certificate, error) {
 
-	_, body, errs := newGet(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).End()
+	r, body, errs := newGet(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get certificate, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	certificate := &Certificate{}
@@ -49,9 +53,13 @@ func (certificateClient *CertificateClient) GetById(id string) (*Certificate, er
 
 func (certificateClient *CertificateClient) Create(certificateRequest *CertificateRequest) (*Certificate, error) {
 
-	_, body, errs := newPost(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath).Send(certificateRequest).End()
+	r, body, errs := newPost(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath).Send(certificateRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new certificate, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdCertificate := &Certificate{}
@@ -69,9 +77,13 @@ func (certificateClient *CertificateClient) Create(certificateRequest *Certifica
 
 func (certificateClient *CertificateClient) DeleteById(id string) error {
 
-	res, _, errs := newDelete(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).End()
+	r, body, errs := newDelete(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete certificate, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete certificate, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil
@@ -79,9 +91,13 @@ func (certificateClient *CertificateClient) DeleteById(id string) error {
 
 func (certificateClient *CertificateClient) List() (*Certificates, error) {
 
-	_, body, errs := newGet(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath).End()
+	r, body, errs := newGet(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get certificates, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	certificates := &Certificates{}
@@ -95,9 +111,13 @@ func (certificateClient *CertificateClient) List() (*Certificates, error) {
 
 func (certificateClient *CertificateClient) UpdateById(id string, certificateRequest *CertificateRequest) (*Certificate, error) {
 
-	_, body, errs := newPatch(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).Send(certificateRequest).End()
+	r, body, errs := newPatch(certificateClient.config, certificateClient.config.HostAddress+CertificatesPath+id).Send(certificateRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update certificate, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedCertificate := &Certificate{}

--- a/vendor/github.com/kevholditch/gokong/consumers.go
+++ b/vendor/github.com/kevholditch/gokong/consumers.go
@@ -47,9 +47,13 @@ func (consumerClient *ConsumerClient) GetByUsername(username string) (*Consumer,
 
 func (consumerClient *ConsumerClient) GetById(id string) (*Consumer, error) {
 
-	_, body, errs := newGet(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).End()
+	r, body, errs := newGet(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get consumer, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	consumer := &Consumer{}
@@ -67,9 +71,13 @@ func (consumerClient *ConsumerClient) GetById(id string) (*Consumer, error) {
 
 func (consumerClient *ConsumerClient) Create(consumerRequest *ConsumerRequest) (*Consumer, error) {
 
-	_, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath).Send(consumerRequest).End()
+	r, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath).Send(consumerRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new consumer, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdConsumer := &Consumer{}
@@ -97,9 +105,13 @@ func (consumerClient *ConsumerClient) ListFiltered(filter *ConsumerFilter) (*Con
 		return nil, fmt.Errorf("could not build query string for consumer filter, error: %v", err)
 	}
 
-	_, body, errs := newGet(consumerClient.config, address).End()
+	r, body, errs := newGet(consumerClient.config, address).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get consumers, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	consumers := &Consumers{}
@@ -117,9 +129,13 @@ func (consumerClient *ConsumerClient) DeleteByUsername(username string) error {
 
 func (consumerClient *ConsumerClient) DeleteById(id string) error {
 
-	res, _, errs := newDelete(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).End()
+	r, body, errs := newDelete(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete consumer, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete consumer, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil
@@ -131,9 +147,13 @@ func (consumerClient *ConsumerClient) UpdateByUsername(username string, consumer
 
 func (consumerClient *ConsumerClient) UpdateById(id string, consumerRequest *ConsumerRequest) (*Consumer, error) {
 
-	_, body, errs := newPatch(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).Send(consumerRequest).End()
+	r, body, errs := newPatch(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+id).Send(consumerRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update consumer, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedConsumer := &Consumer{}
@@ -151,9 +171,13 @@ func (consumerClient *ConsumerClient) UpdateById(id string, consumerRequest *Con
 
 func (consumerClient *ConsumerClient) CreatePluginConfig(consumerId string, pluginName string, pluginConfig string) (*ConsumerPluginConfig, error) {
 
-	_, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName).Send(pluginConfig).End()
+	r, body, errs := newPost(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName).Send(pluginConfig).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not configure plugin for consumer, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdConsumerPluginConfig := &ConsumerPluginConfig{}
@@ -173,9 +197,13 @@ func (consumerClient *ConsumerClient) CreatePluginConfig(consumerId string, plug
 
 func (consumerClient *ConsumerClient) GetPluginConfig(consumerId string, pluginName string, id string) (*ConsumerPluginConfig, error) {
 
-	_, body, errs := newGet(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName+"/"+id).End()
+	r, body, errs := newGet(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName+"/"+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get plugin config for consumer, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	consumerPluginConfig := &ConsumerPluginConfig{}
@@ -195,9 +223,13 @@ func (consumerClient *ConsumerClient) GetPluginConfig(consumerId string, pluginN
 
 func (consumerClient *ConsumerClient) DeletePluginConfig(consumerId string, pluginName string, id string) error {
 
-	_, _, errs := newDelete(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName+"/"+id).End()
+	r, body, errs := newDelete(consumerClient.config, consumerClient.config.HostAddress+ConsumersPath+consumerId+"/"+pluginName+"/"+id).End()
 	if errs != nil {
 		return fmt.Errorf("could not delete plugin config for consumer, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil

--- a/vendor/github.com/kevholditch/gokong/plugins.go
+++ b/vendor/github.com/kevholditch/gokong/plugins.go
@@ -50,9 +50,13 @@ const PluginsPath = "/plugins/"
 
 func (pluginClient *PluginClient) GetById(id string) (*Plugin, error) {
 
-	_, body, errs := newGet(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).End()
+	r, body, errs := newGet(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get plugin, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	plugin := &Plugin{}
@@ -80,9 +84,13 @@ func (pluginClient *PluginClient) ListFiltered(filter *PluginFilter) (*Plugins, 
 		return nil, fmt.Errorf("could not build query string for plugins filter, error: %v", err)
 	}
 
-	_, body, errs := newGet(pluginClient.config, address).End()
+	r, body, errs := newGet(pluginClient.config, address).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get plugins, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	plugins := &Plugins{}
@@ -96,9 +104,13 @@ func (pluginClient *PluginClient) ListFiltered(filter *PluginFilter) (*Plugins, 
 
 func (pluginClient *PluginClient) Create(pluginRequest *PluginRequest) (*Plugin, error) {
 
-	_, body, errs := newPost(pluginClient.config, pluginClient.config.HostAddress+PluginsPath).Send(pluginRequest).End()
+	r, body, errs := newPost(pluginClient.config, pluginClient.config.HostAddress+PluginsPath).Send(pluginRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new plugin, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdPlugin := &Plugin{}
@@ -116,9 +128,13 @@ func (pluginClient *PluginClient) Create(pluginRequest *PluginRequest) (*Plugin,
 
 func (pluginClient *PluginClient) UpdateById(id string, pluginRequest *PluginRequest) (*Plugin, error) {
 
-	_, body, errs := newPatch(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).Send(pluginRequest).End()
+	r, body, errs := newPatch(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).Send(pluginRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update plugin, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedPlugin := &Plugin{}
@@ -136,9 +152,13 @@ func (pluginClient *PluginClient) UpdateById(id string, pluginRequest *PluginReq
 
 func (pluginClient *PluginClient) DeleteById(id string) error {
 
-	res, _, errs := newDelete(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).End()
+	r, body, errs := newDelete(pluginClient.config, pluginClient.config.HostAddress+PluginsPath+id).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete plugin, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete plugin, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil

--- a/vendor/github.com/kevholditch/gokong/routes.go
+++ b/vendor/github.com/kevholditch/gokong/routes.go
@@ -51,9 +51,13 @@ type RouteQueryString struct {
 const RoutesPath = "/routes/"
 
 func (routeClient *RouteClient) AddRoute(routeRequest *RouteRequest) (*Route, error) {
-	_, body, errs := newPost(routeClient.config, routeClient.config.HostAddress+RoutesPath).Send(routeRequest).End()
+	r, body, errs := newPost(routeClient.config, routeClient.config.HostAddress+RoutesPath).Send(routeRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not register the route, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdRoute := &Route{}
@@ -70,9 +74,13 @@ func (routeClient *RouteClient) AddRoute(routeRequest *RouteRequest) (*Route, er
 }
 
 func (routeClient *RouteClient) GetRoute(id string) (*Route, error) {
-	_, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).End()
+	r, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get the route, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	route := &Route{}
@@ -101,9 +109,13 @@ func (routeClient *RouteClient) GetRoutes(query *RouteQueryString) ([]*Route, er
 	}
 
 	for {
-		_, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+RoutesPath).Query(query).End()
+		r, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+RoutesPath).Query(query).End()
 		if errs != nil {
 			return nil, fmt.Errorf("could not get the route, error: %v", errs)
+		}
+
+		if r.StatusCode == 401 || r.StatusCode == 403 {
+			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 		}
 
 		err := json.Unmarshal([]byte(body), data)
@@ -132,9 +144,13 @@ func (routeClient *RouteClient) GetRoutesFromServiceId(id string) ([]*Route, err
 	data := &Routes{}
 
 	for {
-		_, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+fmt.Sprintf("/services/%s/routes", id)).End()
+		r, body, errs := newGet(routeClient.config, routeClient.config.HostAddress+fmt.Sprintf("/services/%s/routes", id)).End()
 		if errs != nil {
 			return nil, fmt.Errorf("could not get the route, error: %v", errs)
+		}
+
+		if r.StatusCode == 401 || r.StatusCode == 403 {
+			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 		}
 
 		err := json.Unmarshal([]byte(body), data)
@@ -153,9 +169,13 @@ func (routeClient *RouteClient) GetRoutesFromServiceId(id string) ([]*Route, err
 }
 
 func (routeClient *RouteClient) UpdateRoute(id string, routeRequest *RouteRequest) (*Route, error) {
-	_, body, errs := newPatch(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).Send(routeRequest).End()
+	r, body, errs := newPatch(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).Send(routeRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update route, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedRoute := &Route{}
@@ -172,9 +192,13 @@ func (routeClient *RouteClient) UpdateRoute(id string, routeRequest *RouteReques
 }
 
 func (routeClient *RouteClient) DeleteRoute(id string) error {
-	res, _, errs := newDelete(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).End()
+	r, body, errs := newDelete(routeClient.config, routeClient.config.HostAddress+RoutesPath+id).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete the route, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete the route, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil

--- a/vendor/github.com/kevholditch/gokong/services.go
+++ b/vendor/github.com/kevholditch/gokong/services.go
@@ -70,9 +70,13 @@ func (serviceClient *ServiceClient) AddService(serviceRequest *ServiceRequest) (
 		serviceRequest.Retries = Int(60000)
 	}
 
-	_, body, errs := newPost(serviceClient.config, serviceClient.config.HostAddress+ServicesPath).Send(serviceRequest).End()
+	r, body, errs := newPost(serviceClient.config, serviceClient.config.HostAddress+ServicesPath).Send(serviceRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not register the service, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdService := &Service{}
@@ -101,9 +105,13 @@ func (serviceClient *ServiceClient) GetServiceFromRouteId(id string) (*Service, 
 }
 
 func (serviceClient *ServiceClient) getService(endpoint string) (*Service, error) {
-	_, body, errs := newGet(serviceClient.config, endpoint).End()
+	r, body, errs := newGet(serviceClient.config, endpoint).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get the service, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	service := &Service{}
@@ -132,9 +140,13 @@ func (serviceClient *ServiceClient) GetServices(query *ServiceQueryString) ([]*S
 	}
 
 	for {
-		_, body, errs := newGet(serviceClient.config, serviceClient.config.HostAddress+ServicesPath).Query(query).End()
+		r, body, errs := newGet(serviceClient.config, serviceClient.config.HostAddress+ServicesPath).Query(query).End()
 		if errs != nil {
 			return nil, fmt.Errorf("could not get the service, error: %v", errs)
+		}
+
+		if r.StatusCode == 401 || r.StatusCode == 403 {
+			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 		}
 
 		err := json.Unmarshal([]byte(body), data)
@@ -167,9 +179,13 @@ func (serviceClient *ServiceClient) UpdateServicebyRouteId(id string, serviceReq
 }
 
 func (serviceClient *ServiceClient) updateService(endpoint string, serviceRequest *ServiceRequest) (*Service, error) {
-	_, body, errs := newPatch(serviceClient.config, endpoint).Send(serviceRequest).End()
+	r, body, errs := newPatch(serviceClient.config, endpoint).Send(serviceRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update service, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedService := &Service{}
@@ -190,9 +206,13 @@ func (serviceClient *ServiceClient) DeleteServiceByName(name string) error {
 }
 
 func (serviceClient *ServiceClient) DeleteServiceById(id string) error {
-	res, _, errs := newDelete(serviceClient.config, serviceClient.config.HostAddress+ServicesPath+id).End()
+	r, body, errs := newDelete(serviceClient.config, serviceClient.config.HostAddress+ServicesPath+id).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete the service, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete the service, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil

--- a/vendor/github.com/kevholditch/gokong/snis.go
+++ b/vendor/github.com/kevholditch/gokong/snis.go
@@ -28,9 +28,13 @@ const SnisPath = "/snis/"
 
 func (snisClient *SnisClient) Create(snisRequest *SnisRequest) (*Sni, error) {
 
-	_, body, errs := newPost(snisClient.config, snisClient.config.HostAddress+SnisPath).Send(snisRequest).End()
+	r, body, errs := newPost(snisClient.config, snisClient.config.HostAddress+SnisPath).Send(snisRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new sni, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	sni := &Sni{}
@@ -48,9 +52,13 @@ func (snisClient *SnisClient) Create(snisRequest *SnisRequest) (*Sni, error) {
 
 func (snisClient *SnisClient) GetByName(name string) (*Sni, error) {
 
-	_, body, errs := newGet(snisClient.config, snisClient.config.HostAddress+SnisPath+name).End()
+	r, body, errs := newGet(snisClient.config, snisClient.config.HostAddress+SnisPath+name).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get sni, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	sni := &Sni{}
@@ -68,9 +76,13 @@ func (snisClient *SnisClient) GetByName(name string) (*Sni, error) {
 
 func (snisClient *SnisClient) List() (*Snis, error) {
 
-	_, body, errs := newGet(snisClient.config, snisClient.config.HostAddress+SnisPath).End()
+	r, body, errs := newGet(snisClient.config, snisClient.config.HostAddress+SnisPath).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get snis, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	snis := &Snis{}
@@ -84,9 +96,13 @@ func (snisClient *SnisClient) List() (*Snis, error) {
 
 func (snisClient *SnisClient) DeleteByName(name string) error {
 
-	res, _, errs := newDelete(snisClient.config, snisClient.config.HostAddress+SnisPath+name).End()
+	r, body, errs := newDelete(snisClient.config, snisClient.config.HostAddress+SnisPath+name).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete sni, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete sni, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil
@@ -94,9 +110,13 @@ func (snisClient *SnisClient) DeleteByName(name string) error {
 
 func (snisClient *SnisClient) UpdateByName(name string, snisRequest *SnisRequest) (*Sni, error) {
 
-	_, body, errs := newPatch(snisClient.config, snisClient.config.HostAddress+SnisPath+name).Send(snisRequest).End()
+	r, body, errs := newPatch(snisClient.config, snisClient.config.HostAddress+SnisPath+name).Send(snisRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update sni, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedSni := &Sni{}

--- a/vendor/github.com/kevholditch/gokong/upstreams.go
+++ b/vendor/github.com/kevholditch/gokong/upstreams.go
@@ -91,9 +91,13 @@ func (upstreamClient *UpstreamClient) GetByName(name string) (*Upstream, error) 
 
 func (upstreamClient *UpstreamClient) GetById(id string) (*Upstream, error) {
 
-	_, body, errs := newGet(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).End()
+	r, body, errs := newGet(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get upstream, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	upstream := &Upstream{}
@@ -111,9 +115,13 @@ func (upstreamClient *UpstreamClient) GetById(id string) (*Upstream, error) {
 
 func (upstreamClient *UpstreamClient) Create(upstreamRequest *UpstreamRequest) (*Upstream, error) {
 
-	_, body, errs := newPost(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath).Send(upstreamRequest).End()
+	r, body, errs := newPost(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath).Send(upstreamRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not create new upstream, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	createdUpstream := &Upstream{}
@@ -135,9 +143,13 @@ func (upstreamClient *UpstreamClient) DeleteByName(name string) error {
 
 func (upstreamClient *UpstreamClient) DeleteById(id string) error {
 
-	res, _, errs := newDelete(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).End()
+	r, body, errs := newDelete(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).End()
 	if errs != nil {
-		return fmt.Errorf("could not delete upstream, result: %v error: %v", res, errs)
+		return fmt.Errorf("could not delete upstream, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	return nil
@@ -155,9 +167,13 @@ func (upstreamClient *UpstreamClient) ListFiltered(filter *UpstreamFilter) (*Ups
 		return nil, fmt.Errorf("could not build query string for upstreams filter, error: %v", err)
 	}
 
-	_, body, errs := newGet(upstreamClient.config, address).End()
+	r, body, errs := newGet(upstreamClient.config, address).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not get upstreams, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	upstreams := &Upstreams{}
@@ -175,9 +191,13 @@ func (upstreamClient *UpstreamClient) UpdateByName(name string, upstreamRequest 
 
 func (upstreamClient *UpstreamClient) UpdateById(id string, upstreamRequest *UpstreamRequest) (*Upstream, error) {
 
-	_, body, errs := newPatch(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).Send(upstreamRequest).End()
+	r, body, errs := newPatch(upstreamClient.config, upstreamClient.config.HostAddress+UpstreamsPath+id).Send(upstreamRequest).End()
 	if errs != nil {
 		return nil, fmt.Errorf("could not update upstream, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
 	}
 
 	updatedUpstream := &Upstream{}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -535,10 +535,10 @@
 			"revisionTime": "2016-08-03T19:07:31Z"
 		},
 		{
-			"checksumSHA1": "b3mQ8dVkpRngbnRQ0Wh7hpYLW0Y=",
+			"checksumSHA1": "OKYx2/l0+UmzGAPujUjF7pLttJk=",
 			"path": "github.com/kevholditch/gokong",
-			"revision": "c1adf45559cf3f834a9ad995f21d6fc7c635f560",
-			"revisionTime": "2018-07-30T20:22:00Z"
+			"revision": "12fe723b6165789826227b5b7122385ade6173e5",
+			"revisionTime": "2018-08-07T12:42:23Z"
 		},
 		{
 			"path": "github.com/kevholditch/gokong...",
@@ -547,8 +547,8 @@
 		{
 			"checksumSHA1": "w9MW3oDsZxi3k5QotS+3iWMa/eg=",
 			"path": "github.com/kevholditch/gokong/containers",
-			"revision": "c1adf45559cf3f834a9ad995f21d6fc7c635f560",
-			"revisionTime": "2018-07-30T20:22:00Z"
+			"revision": "12fe723b6165789826227b5b7122385ade6173e5",
+			"revisionTime": "2018-08-07T12:42:23Z"
 		},
 		{
 			"checksumSHA1": "IfZcD4U1dtllJKlPNeD2aU4Jn98=",


### PR DESCRIPTION
currently if a request is unauthorised to kong then gokong would return
a `nil` error and a `nil` resource.  The `v1.8.0` release of `gokong`
fixes this and now a non `nil` error is returned in this case.

fixed a small bug in the if statement when creating an api resource to
stop a nil pointer exception from being possible.

fixes #18
fixes #34