### PR TITLE
Add the ability to configure a plugin with JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test:
 	go test -v . ./kong
 
 testacc:
-	go test -v ./kong -run="TestAcc"
+	TF_ACC=1 go test -v ./kong -run="TestAcc"
 
 build: goimportscheck vet testacc
 	@go install

--- a/kong/resource_kong_plugin_test.go
+++ b/kong/resource_kong_plugin_test.go
@@ -191,6 +191,29 @@ func TestAccKongPluginForASpecificRoute(t *testing.T) {
 	})
 }
 
+func TestAccKongPluginWithJson(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKongPluginDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCreatePluginWithJson,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongPluginExists("kong_plugin.datadog_test"),
+					resource.TestCheckResourceAttr("kong_plugin.datadog_test", "name", "datadog"),
+				),
+			},
+			{
+				Config: testUpdatePluginWithJson,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongPluginExists("kong_plugin.datadog_test"),
+					resource.TestCheckResourceAttr("kong_plugin.datadog_test", "name", "datadog"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKongPluginImport(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
@@ -564,5 +587,50 @@ resource "kong_plugin" "basic_auth" {
 	config = {
 		hide_credentials = "false"
 	}
+}
+`
+
+const testCreatePluginWithJson = `
+resource "kong_plugin" "datadog_test" {
+	name  = "datadog"
+	config_json = <<EOT
+	{
+	  "host": "datadog",
+	  "prefix": "kong",
+	  "port": 8125,
+	  "metrics": [
+	    {
+	      "sample_rate": 1,
+	      "name": "request_count",
+	      "stat_type": "counter"
+	    }
+	  ]
+	}
+	EOT
+}
+`
+
+const testUpdatePluginWithJson = `
+resource "kong_plugin" "datadog_test" {
+	name  = "datadog"
+	config_json = <<EOT
+	{
+	  "host": "datadog",
+	  "prefix": "kong",
+	  "port": 8125,
+	  "metrics": [
+	    {
+	      "sample_rate": 1,
+	      "name": "request_count",
+	      "stat_type": "counter"
+	    },
+	    {
+	      "sample_rate": 1,
+	      "name": "latency",
+	      "stat_type": "gauge"
+	    }
+	  ]
+	}
+	EOT
 }
 `


### PR DESCRIPTION
This was the easiest approach as opposed to changing the underlying SDK to take raw JSON but I think it is suitable for all possible plugin configurations.

Fixes #11

![screen shot 2018-11-27 at 10 09 46 am](https://user-images.githubusercontent.com/14934291/49095263-ba6dac80-f22d-11e8-94c0-6663ec2608cb.png)
