### PR TITLE
Sync plugin json upstream per best practices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test:
 	go test -v . ./kong
 
 testacc:
-	go test -v ./kong -run="TestAcc"
+	TF_ACC=1 go test -v ./kong -run="TestAcc"
 
 build: goimportscheck vet testacc
 	@go install

--- a/kong/resource_kong_consumer_plugin_config_test.go
+++ b/kong/resource_kong_consumer_plugin_config_test.go
@@ -20,7 +20,7 @@ func TestAccKongConsumerPluginConfig(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKongConsumerPluginConfigExists("kong_consumer_plugin_config.consumer_jwt_config"),
 					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_jwt_config", "plugin_name", "jwt"),
-					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_jwt_config", "config_json", `{"key":"my_key","secret":"my_secret"}`),
+					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_jwt_config", "config_json", `{"algorithm":"HS256","key":"my_key","secret":"my_secret"}`),
 				),
 			},
 			{
@@ -28,7 +28,7 @@ func TestAccKongConsumerPluginConfig(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKongConsumerPluginConfigExists("kong_consumer_plugin_config.consumer_jwt_config"),
 					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_jwt_config", "plugin_name", "jwt"),
-					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_jwt_config", "config_json", `{"key":"updated_key","secret":"updated_secret"}`),
+					resource.TestCheckResourceAttr("kong_consumer_plugin_config.consumer_jwt_config", "config_json", `{"algorithm":"HS256","key":"updated_key","secret":"updated_secret"}`),
 				),
 			},
 		},
@@ -162,6 +162,7 @@ resource "kong_consumer_plugin_config" "consumer_jwt_config" {
 	plugin_name = "jwt"
 	config_json = <<EOT
 		{
+			"algorithm": "HS256",
 			"key": "my_key",
 			"secret": "my_secret"
 		}
@@ -187,6 +188,7 @@ resource "kong_consumer_plugin_config" "consumer_jwt_config" {
 	plugin_name = "jwt"
 	config_json = <<EOT
 		{
+			"algorithm": "HS256",
 			"key": "updated_key",
 			"secret": "updated_secret"
 		}

--- a/kong/resource_kong_plugin_test.go
+++ b/kong/resource_kong_plugin_test.go
@@ -191,6 +191,29 @@ func TestAccKongPluginForASpecificRoute(t *testing.T) {
 	})
 }
 
+func TestAccKongPluginWithJson(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKongPluginDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCreatePluginWithJson,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongPluginExists("kong_plugin.datadog_test"),
+					resource.TestCheckResourceAttr("kong_plugin.datadog_test", "name", "datadog"),
+				),
+			},
+			{
+				Config: testUpdatePluginWithJson,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongPluginExists("kong_plugin.datadog_test"),
+					resource.TestCheckResourceAttr("kong_plugin.datadog_test", "name", "datadog"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKongPluginImport(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
@@ -564,5 +587,50 @@ resource "kong_plugin" "basic_auth" {
 	config = {
 		hide_credentials = "false"
 	}
+}
+`
+
+const testCreatePluginWithJson = `
+resource "kong_plugin" "datadog_test" {
+	name  = "datadog"
+	config_json = <<EOT
+	{
+	  "host": "datadog",
+	  "prefix": "kong",
+	  "port": 8125,
+	  "metrics": [
+	    {
+	      "sample_rate": 1,
+	      "name": "request_count",
+	      "stat_type": "counter"
+	    }
+	  ]
+	}
+	EOT
+}
+`
+
+const testUpdatePluginWithJson = `
+resource "kong_plugin" "datadog_test" {
+	name  = "datadog"
+	config_json = <<EOT
+	{
+	  "host": "datadog",
+	  "prefix": "kong",
+	  "port": 8125,
+	  "metrics": [
+	    {
+	      "sample_rate": 1,
+	      "name": "request_count",
+	      "stat_type": "counter"
+	    },
+	    {
+	      "sample_rate": 1,
+	      "name": "latency",
+	      "stat_type": "gauge"
+	    }
+	  ]
+	}
+	EOT
 }
 `

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -1,0 +1,34 @@
+package kong
+
+import (
+	"fmt"
+	"strconv"
+)
+
+var computedPluginProperties = []string{"created_at", "id", "consumer_id"}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+
+	return false
+}
+
+// For the plugin config blobs, since there is no schema,
+// we need to convert the values to a string to match config and avoid a diff.
+func convertInterfaceToString(val interface{}) string {
+	if s, ok := val.(string); ok {
+		return s
+	} else if b, ok := val.(bool); ok {
+		return strconv.FormatBool(b)
+	} else if f, ok := val.(float64); ok {
+		return fmt.Sprintf("%f", f)
+	} else if i, ok := val.(int); ok {
+		return strconv.Itoa(i)
+	}
+
+	return ""
+}


### PR DESCRIPTION
* Add `config_json` to plugin, fixes #11 

* While using this plugin I ran into an issue with importing existing consumer plugins. This was due to the ForceNew property and the lack of setting this property in the read function. Per terraform best practices properties should be sync'd with upstream via the read function. To get the best of both worlds I am only syncing `config_json` when it is set in the config. I attempted syncing both but it gets quite involved attempting to normalize the API's config to match the state of the `config` property. This is especially true when the plugin config has defaults, this all results in a perpetual diff. I am not sure of a better way to approach this other then defining a schema per plugin type.

https://www.terraform.io/docs/extend/best-practices/detecting-drift.html#capture-all-state-in-read

![screen shot 2018-12-11 at 4 34 57 pm](https://user-images.githubusercontent.com/14934291/49834719-b8920600-fd62-11e8-9ad2-299fa004b21b.png)

