### PR TITLE
Kong pre 1.0.0 - Upstreams & Targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,28 @@ Each of the filter parameters are optional and they are combined for an AND sear
   * `healthchecks.passive.unhealthy.http_statuses` is an array of HTTP statuses which represent unhealthiness when produced by proxied traffic, as observed by passive health checks. Defaults to `[429, 500, 503]`.
   * `order_list` - a list containing the slot order on the found upstream
 
+To import an upstream:
+```
+terraform import kong_upstream.<upstream_identifier> <upstream_id>
+```
+
+## Targets
+```hcl
+resource "kong_target" "target" {
+    target  		= "sample_target:80"
+    weight 	  	= 10
+    upstream_id = "${kong_upstream.upstream.id}"
+}
+```
+`target` is the target address (IP or hostname) and port. If omitted the port defaults to 8000.
+`weight` is the weight this target gets within the upstream load balancer (0-1000, defaults to 100).
+`upstream_id` is the id of the upstream to apply this target to.
+
+
+To import a target use a combination of the upstream id and the target id as follows:
+```
+terraform import kong_target.<target_identifier> <upstream_id>/<target_id>
+```
 
 # Contributing
 I would love to get contributions to the project so please feel free to submit a PR.  To setup your dev station you need go and docker installed.
@@ -473,4 +495,3 @@ goimports needs running on the following files:
 Then all you need to do is run `make goimports` this will reformat all of the code (I know awesome)!!
 
 Please write tests for your new feature/bug fix, PRs will only be accepted with covering tests and where all tests pass.  If you want to start work on a feature feel free to open a PR early so we can discuss it or if you need help.
-

--- a/kong/data_source_upstream.go
+++ b/kong/data_source_upstream.go
@@ -39,6 +39,191 @@ func dataSourceKongUpstream() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"hash_on": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Default:  "none",
+			},
+			"hash_fallback": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Default:  "none",
+			},
+			"hash_on_header": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Default:  nil,
+			},
+			"hash_fallback_header": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Default:  nil,
+			},
+			"healthchecks": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"active": &schema.Schema{
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"timeout": &schema.Schema{
+										Type:     schema.TypeInt,
+										Optional: true,
+										Default:  1,
+									},
+									"concurrency": &schema.Schema{
+										Type:     schema.TypeInt,
+										Optional: true,
+										Default:  10,
+									},
+									"http_path": &schema.Schema{
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "/",
+									},
+									"healthy": &schema.Schema{
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"interval": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+													Computed: true,
+												},
+												"http_statuses": &schema.Schema{
+													Type:     schema.TypeList,
+													Optional: true,
+													Computed: true,
+													Elem: &schema.Schema{
+														Type: schema.TypeInt,
+													},
+												},
+												"successes": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"unhealthy": &schema.Schema{
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"interval": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+													Computed: true,
+												},
+												"http_statuses": &schema.Schema{
+													Type:     schema.TypeList,
+													Optional: true,
+													Computed: true,
+													Elem: &schema.Schema{
+														Type: schema.TypeInt,
+													},
+												},
+												"tcp_failures": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+													Computed: true,
+												},
+												"http_failures": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+													Computed: true,
+												},
+												"timeouts": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"passive": &schema.Schema{
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"healthy": &schema.Schema{
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"http_statuses": &schema.Schema{
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Schema{
+														Type: schema.TypeInt,
+													},
+												},
+												"successes": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+											},
+										},
+									},
+									"unhealthy": &schema.Schema{
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"http_statuses": &schema.Schema{
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Schema{
+														Type: schema.TypeInt,
+													},
+												},
+												"tcp_failures": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+												"http_failures": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+												"timeouts": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"order_list": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -82,6 +267,13 @@ func dataSourceKongUpstreamRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("id", upstream.Id)
 	d.Set("name", upstream.Name)
 	d.Set("slots", upstream.Slots)
+	d.Set("hash_on", upstream.HashOn)
+	d.Set("hash_fallback", upstream.HashFallback)
+	d.Set("hash_on_header", upstream.HashOnHeader)
+	d.Set("hash_fallback_header", upstream.HashFallbackHeader)
+	if err := d.Set("healthchecks", flattenHealthCheck(upstream.HealthChecks)); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/kong/data_source_upstream_test.go
+++ b/kong/data_source_upstream_test.go
@@ -16,6 +16,34 @@ func TestAccDataSourceKongUpstream(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "name", "TestUpstream"),
 					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "slots", "10"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "hash_on", "header"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "hash_fallback", "consumer"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "hash_on_header", "HeaderName"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "hash_fallback_header", "FallbackHeaderName"),
+
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.active.0.timeout", "10"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.active.0.concurrency", "20"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.active.0.http_path", "/status"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.active.0.healthy.0.interval", "5"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.active.0.healthy.0.successes", "1"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.active.0.healthy.0.http_statuses.0", "200"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.active.0.healthy.0.http_statuses.1", "201"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.active.0.unhealthy.0.interval", "3"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.active.0.unhealthy.0.tcp_failures", "1"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.active.0.unhealthy.0.http_failures", "2"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.active.0.unhealthy.0.timeouts", "7"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.active.0.unhealthy.0.http_statuses.0", "500"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.active.0.unhealthy.0.http_statuses.1", "501"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.passive.0.healthy.0.successes", "1"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.passive.0.healthy.0.http_statuses.0", "200"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.passive.0.healthy.0.http_statuses.1", "201"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.passive.0.healthy.0.http_statuses.2", "202"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.passive.0.unhealthy.0.tcp_failures", "5"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.passive.0.unhealthy.0.http_failures", "6"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.passive.0.unhealthy.0.timeouts", "3"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.passive.0.unhealthy.0.http_statuses.0", "500"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.passive.0.unhealthy.0.http_statuses.1", "501"),
+					resource.TestCheckResourceAttr("data.kong_upstream.upstream_data_source", "healthchecks.0.passive.0.unhealthy.0.http_statuses.2", "502"),
 				),
 			},
 		},
@@ -26,6 +54,41 @@ const testUpstreamDataSourceConfig = `
 resource "kong_upstream" "upstream" {
 	name  		= "TestUpstream"
 	slots 		= 10
+	hash_on              = "header"
+	hash_fallback        = "consumer"
+	hash_on_header       = "HeaderName"
+	hash_fallback_header = "FallbackHeaderName"
+	healthchecks         = {
+		active = {
+			http_path    = "/status"
+			timeout      = 10
+			concurrency  = 20
+			healthy = {
+				successes = 1
+				interval  = 5
+				http_statuses = [200, 201]
+			}
+			unhealthy = {
+				timeouts      = 7
+				interval      = 3
+				tcp_failures  = 1
+				http_failures = 2
+				http_statuses = [500, 501]
+			}
+		}
+		passive = {
+			healthy = {
+				successes = 1
+				http_statuses = [200, 201, 202]
+			}
+			unhealthy = {
+				timeouts      = 3
+				tcp_failures  = 5
+				http_failures = 6
+				http_statuses = [500, 501, 502]
+			}
+		}
+	}
 }
 
 data "kong_upstream" "upstream_data_source" {

--- a/kong/provider.go
+++ b/kong/provider.go
@@ -57,6 +57,7 @@ func Provider() terraform.ResourceProvider {
 			"kong_plugin":                 resourceKongPlugin(),
 			"kong_sni":                    resourceKongSni(),
 			"kong_upstream":               resourceKongUpstream(),
+			"kong_target":                 resourceKongTarget(),
 			"kong_service":                resourceKongService(),
 			"kong_route":                  resourceKongRoute(),
 		},

--- a/kong/resource_kong_target.go
+++ b/kong/resource_kong_target.go
@@ -1,0 +1,96 @@
+package kong
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/kevholditch/gokong"
+)
+
+func resourceKongTarget() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceKongTargetCreate,
+		Read:   resourceKongTargetRead,
+		Delete: resourceKongTargetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"target": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"weight": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"upstream_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceKongTargetCreate(d *schema.ResourceData, meta interface{}) error {
+
+	targetRequest := createKongTargetRequestFromResourceData(d)
+
+	target, err := meta.(*gokong.KongAdminClient).Targets().CreateFromUpstreamId(readStringFromResource(d, "upstream_id"), targetRequest)
+
+	if err != nil {
+		return fmt.Errorf("failed to create kong target: %v error: %v", targetRequest, err)
+	}
+
+	d.SetId(*target.Upstream + "/" + *target.Id)
+
+	return resourceKongTargetRead(d, meta)
+}
+
+func resourceKongTargetRead(d *schema.ResourceData, meta interface{}) error {
+
+	var ids = strings.Split(d.Id(), "/")
+	targets, err := meta.(*gokong.KongAdminClient).Targets().GetTargetsFromUpstreamId(ids[0])
+
+	if err != nil {
+		return fmt.Errorf("could not find kong target: %v", err)
+	}
+
+	if targets == nil {
+		d.SetId("")
+	} else {
+		for _, element := range targets {
+			if *element.Id == ids[1] {
+				d.Set("target", element.Target)
+				d.Set("weight", element.Weight)
+				d.Set("upstream_id", element.Upstream)
+			}
+		}
+	}
+
+	return nil
+}
+
+func resourceKongTargetDelete(d *schema.ResourceData, meta interface{}) error {
+
+	var ids = strings.Split(d.Id(), "/")
+	err := meta.(*gokong.KongAdminClient).Targets().DeleteFromUpstreamById(ids[0], ids[1])
+
+	if err != nil {
+		return fmt.Errorf("could not delete kong target: %v", err)
+	}
+
+	return nil
+}
+
+func createKongTargetRequestFromResourceData(d *schema.ResourceData) *gokong.TargetRequest {
+	return &gokong.TargetRequest{
+		Target: readStringFromResource(d, "target"),
+		Weight: readIntFromResource(d, "weight"),
+	}
+}

--- a/kong/resource_kong_target_test.go
+++ b/kong/resource_kong_target_test.go
@@ -1,0 +1,202 @@
+package kong
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/kevholditch/gokong"
+)
+
+func TestAccKongTarget(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKongTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCreateTargetConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongTargetExists("kong_target.target"),
+					resource.TestCheckResourceAttr("kong_target.target", "target", "mytarget:4000"),
+					resource.TestCheckResourceAttr("kong_target.target", "weight", "100"),
+				),
+			},
+			{
+				Config: testUpdateTargetConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongTargetExists("kong_target.target"),
+					resource.TestCheckResourceAttr("kong_target.target", "target", "mytarget:4000"),
+					resource.TestCheckResourceAttr("kong_target.target", "weight", "200"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKongTargetDelete(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKongTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCreateTargetConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongTargetExists("kong_target.target"),
+					resource.TestCheckResourceAttr("kong_target.target", "target", "mytarget:4000"),
+					resource.TestCheckResourceAttr("kong_target.target", "weight", "100"),
+				),
+			},
+			{
+				Config: testDeleteTargetConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongTargetDoesNotExist("kong_target.target", "kong_upstream.upstream"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKongTargetImport(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKongTargetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testCreateTargetConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      "kong_target.target",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckKongTargetDestroy(state *terraform.State) error {
+
+	client := testAccProvider.Meta().(*gokong.KongAdminClient)
+
+	targets := getResourcesByType("kong_target", state)
+
+	if len(targets) > 1 {
+		return fmt.Errorf("expecting max 1 target resource found %v", len(targets))
+	}
+
+	if len(targets) == 0 {
+		return nil
+	}
+
+	response, _ := client.Targets().GetTargetsFromUpstreamId(targets[0].Primary.Attributes["upstream_id"])
+
+	if response != nil {
+		for _, element := range response {
+			if *element.Id == targets[0].Primary.ID {
+				return fmt.Errorf("target %s still exists, %+v", targets[0].Primary.ID, response)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckKongTargetExists(resourceKey string) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceKey]
+
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceKey)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		var ids = strings.Split(rs.Primary.ID, "/")
+		api, err := testAccProvider.Meta().(*gokong.KongAdminClient).Targets().GetTargetsFromUpstreamId(ids[0])
+
+		if err != nil {
+			return err
+		}
+
+		if api == nil {
+			return fmt.Errorf("target with id %v not found", rs.Primary.ID)
+		}
+
+		for _, element := range api {
+			if *element.Id == ids[1] {
+				break
+			}
+
+			return fmt.Errorf("target with id %v not found", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckKongTargetDoesNotExist(targetResourceKey string, upstreamResourceKey string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[targetResourceKey]
+
+		if ok {
+			return fmt.Errorf("Found target: %s", targetResourceKey)
+		}
+
+		rs, ok = s.RootModule().Resources[upstreamResourceKey]
+
+		if !ok {
+			return fmt.Errorf("not found: %s", upstreamResourceKey)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no upstream ID is set")
+		}
+
+		targets, _ := testAccProvider.Meta().(*gokong.KongAdminClient).Targets().GetTargetsFromUpstreamId(rs.Primary.ID)
+
+		if len(targets) > 0 {
+			return fmt.Errorf("expecting zero target resources found %v", len(targets))
+		}
+
+		return nil
+	}
+}
+
+const testCreateTargetConfig = `
+resource "kong_upstream" "upstream" {
+	name				= "MyUpstream"
+	slots				= 10
+}
+
+resource "kong_target" "target" {
+	target			= "mytarget:4000"
+	weight			= 100
+	upstream_id	= "${kong_upstream.upstream.id}"
+}
+`
+const testUpdateTargetConfig = `
+resource "kong_upstream" "upstream" {
+	name				= "MyUpstream"
+	slots 			= 10
+}
+
+resource "kong_target" "target" {
+	target			= "mytarget:4000"
+	weight			= 200
+	upstream_id	= "${kong_upstream.upstream.id}"
+}
+`
+const testDeleteTargetConfig = `
+resource "kong_upstream" "upstream" {
+	name				= "MyUpstream"
+	slots				= 10
+}
+`

--- a/kong/resource_kong_upstream.go
+++ b/kong/resource_kong_upstream.go
@@ -12,6 +12,7 @@ func resourceKongUpstream() *schema.Resource {
 		Create: resourceKongUpstreamCreate,
 		Read:   resourceKongUpstreamRead,
 		Delete: resourceKongUpstreamDelete,
+		Update: resourceKongUpstreamUpdate,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -20,12 +21,198 @@ func resourceKongUpstream() *schema.Resource {
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
+				ForceNew: false,
 			},
 			"slots": &schema.Schema{
 				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
+				Optional: true,
+				ForceNew: false,
+				Default:  10000,
+			},
+			"hash_on": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Default:  "none",
+			},
+			"hash_fallback": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Default:  "none",
+			},
+			"hash_on_header": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Default:  nil,
+			},
+			"hash_fallback_header": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+				Default:  nil,
+			},
+			"healthchecks": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"active": &schema.Schema{
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"timeout": &schema.Schema{
+										Type:     schema.TypeInt,
+										Optional: true,
+										Default:  1,
+									},
+									"concurrency": &schema.Schema{
+										Type:     schema.TypeInt,
+										Optional: true,
+										Default:  10,
+									},
+									"http_path": &schema.Schema{
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "/",
+									},
+									"healthy": &schema.Schema{
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"interval": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+													Computed: true,
+												},
+												"http_statuses": &schema.Schema{
+													Type:     schema.TypeList,
+													Optional: true,
+													Computed: true,
+													Elem: &schema.Schema{
+														Type: schema.TypeInt,
+													},
+												},
+												"successes": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+													Computed: true,
+												},
+											},
+										},
+									},
+									"unhealthy": &schema.Schema{
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"interval": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+													Computed: true,
+												},
+												"http_statuses": &schema.Schema{
+													Type:     schema.TypeList,
+													Optional: true,
+													Computed: true,
+													Elem: &schema.Schema{
+														Type: schema.TypeInt,
+													},
+												},
+												"tcp_failures": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+													Computed: true,
+												},
+												"http_failures": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+													Computed: true,
+												},
+												"timeouts": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"passive": &schema.Schema{
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"healthy": &schema.Schema{
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"http_statuses": &schema.Schema{
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Schema{
+														Type: schema.TypeInt,
+													},
+												},
+												"successes": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+											},
+										},
+									},
+									"unhealthy": &schema.Schema{
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Computed: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"http_statuses": &schema.Schema{
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Schema{
+														Type: schema.TypeInt,
+													},
+												},
+												"tcp_failures": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+												"http_failures": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+												"timeouts": &schema.Schema{
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -46,6 +233,20 @@ func resourceKongUpstreamCreate(d *schema.ResourceData, meta interface{}) error 
 	return resourceKongUpstreamRead(d, meta)
 }
 
+func resourceKongUpstreamUpdate(d *schema.ResourceData, meta interface{}) error {
+	d.Partial(false)
+
+	upstreamRequest := createKongUpstreamRequestFromResourceData(d)
+
+	_, err := meta.(*gokong.KongAdminClient).Upstreams().UpdateById(d.Id(), upstreamRequest)
+
+	if err != nil {
+		return fmt.Errorf("error updating kong upstream: %s", err)
+	}
+
+	return resourceKongUpstreamRead(d, meta)
+}
+
 func resourceKongUpstreamRead(d *schema.ResourceData, meta interface{}) error {
 
 	upstream, err := meta.(*gokong.KongAdminClient).Upstreams().GetById(d.Id())
@@ -59,6 +260,13 @@ func resourceKongUpstreamRead(d *schema.ResourceData, meta interface{}) error {
 	} else {
 		d.Set("name", upstream.Name)
 		d.Set("slots", upstream.Slots)
+		d.Set("hash_on", upstream.HashOn)
+		d.Set("hash_fallback", upstream.HashFallback)
+		d.Set("hash_on_header", upstream.HashOnHeader)
+		d.Set("hash_fallback_header", upstream.HashFallbackHeader)
+		if err := d.Set("healthchecks", flattenHealthCheck(upstream.HealthChecks)); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -81,6 +289,293 @@ func createKongUpstreamRequestFromResourceData(d *schema.ResourceData) *gokong.U
 
 	upstreamRequest.Name = readStringFromResource(d, "name")
 	upstreamRequest.Slots = readIntFromResource(d, "slots")
+	upstreamRequest.HashOn = readStringFromResource(d, "hash_on")
+	upstreamRequest.HashFallback = readStringFromResource(d, "hash_fallback")
+	upstreamRequest.HashOnHeader = readStringFromResource(d, "hash_on_header")
+	upstreamRequest.HashFallbackHeader = readStringFromResource(d, "hash_fallback_header")
+
+	if healthChecksArray := readArrayFromResource(d, "healthchecks"); healthChecksArray != nil && len(healthChecksArray) > 0 {
+		healthChecksMap := healthChecksArray[0].(map[string]interface{})
+		upstreamRequest.HealthChecks = createKongHealthCheckFromMap(&healthChecksMap)
+	}
 
 	return upstreamRequest
+}
+
+func createKongHealthCheckFromMap(data *map[string]interface{}) *gokong.UpstreamHealthCheck {
+	if data != nil {
+		dataMap := *data
+		healthCheck := &gokong.UpstreamHealthCheck{}
+
+		if dataMap["active"] != nil {
+			if activeArray := dataMap["active"].([]interface{}); activeArray != nil && len(activeArray) > 0 {
+				activeMap := activeArray[0].(map[string]interface{})
+				healthCheck.Active = createKongHealthCheckActiveFromMap(&activeMap)
+			}
+		}
+
+		if dataMap["passive"] != nil {
+			if passiveArray := dataMap["passive"].([]interface{}); passiveArray != nil && len(passiveArray) > 0 {
+				passiveMap := passiveArray[0].(map[string]interface{})
+				healthCheck.Passive = createKongHealthCheckPassiveFromMap(&passiveMap)
+			}
+		}
+
+		return healthCheck
+	}
+	return nil
+}
+
+func createKongHealthCheckActiveFromMap(data *map[string]interface{}) *gokong.UpstreamHealthCheckActive {
+	if data != nil {
+		dataMap := *data
+		active := &gokong.UpstreamHealthCheckActive{}
+
+		if dataMap["timeout"] != nil {
+			active.Timeout = dataMap["timeout"].(int)
+		}
+		if dataMap["concurrency"] != nil {
+			active.Concurrency = dataMap["concurrency"].(int)
+		}
+		if dataMap["http_path"] != nil {
+			active.HttpPath = dataMap["http_path"].(string)
+		}
+
+		if dataMap["healthy"] != nil {
+			if healthyArray := dataMap["healthy"].([]interface{}); healthyArray != nil && len(healthyArray) > 0 {
+				healthyMap := healthyArray[0].(map[string]interface{})
+				active.Healthy = createKongActiveHealthyFromMap(&healthyMap)
+			}
+		}
+
+		if dataMap["unhealthy"] != nil {
+			if unhealthyArray := dataMap["unhealthy"].([]interface{}); unhealthyArray != nil && len(unhealthyArray) > 0 {
+				unhealthyMap := unhealthyArray[0].(map[string]interface{})
+				active.Unhealthy = createKongActiveUnhealthyFromMap(&unhealthyMap)
+			}
+		}
+
+		return active
+	}
+
+	return nil
+}
+
+func createKongHealthCheckPassiveFromMap(data *map[string]interface{}) *gokong.UpstreamHealthCheckPassive {
+	if data != nil {
+		dataMap := *data
+		passive := &gokong.UpstreamHealthCheckPassive{}
+
+		if dataMap["healthy"] != nil {
+			if healthyArray := dataMap["healthy"].([]interface{}); healthyArray != nil && len(healthyArray) > 0 {
+				healthyMap := healthyArray[0].(map[string]interface{})
+				passive.Healthy = createKongPassiveHealthyFromMap(&healthyMap)
+			}
+		}
+
+		if dataMap["unhealthy"] != nil {
+			if unhealthyArray := dataMap["unhealthy"].([]interface{}); unhealthyArray != nil && len(unhealthyArray) > 0 {
+				unhealthyMap := unhealthyArray[0].(map[string]interface{})
+				passive.Unhealthy = createKongPassiveUnhealthyFromMap(&unhealthyMap)
+			}
+		}
+
+		return passive
+	}
+
+	return nil
+}
+
+func createKongActiveHealthyFromMap(data *map[string]interface{}) *gokong.ActiveHealthy {
+	if data != nil {
+		dataMap := *data
+		healthy := &gokong.ActiveHealthy{}
+
+		if dataMap["interval"] != nil {
+			healthy.Interval = dataMap["interval"].(int)
+		}
+		if dataMap["http_statuses"] != nil {
+			healthy.HttpStatuses = readIntArrayFromInterface(dataMap["http_statuses"])
+		}
+		if dataMap["successes"] != nil {
+			healthy.Successes = dataMap["successes"].(int)
+		}
+
+		return healthy
+	}
+	return nil
+}
+
+func createKongActiveUnhealthyFromMap(data *map[string]interface{}) *gokong.ActiveUnhealthy {
+	if data != nil {
+		dataMap := *data
+		unhealthy := &gokong.ActiveUnhealthy{}
+
+		if dataMap["interval"] != nil {
+			unhealthy.Interval = dataMap["interval"].(int)
+		}
+		if dataMap["http_statuses"] != nil {
+			unhealthy.HttpStatuses = readIntArrayFromInterface(dataMap["http_statuses"])
+		}
+		if dataMap["tcp_failures"] != nil {
+			unhealthy.TcpFailures = dataMap["tcp_failures"].(int)
+		}
+		if dataMap["http_failures"] != nil {
+			unhealthy.HttpFailures = dataMap["http_failures"].(int)
+		}
+		if dataMap["timeouts"] != nil {
+			unhealthy.Timeouts = dataMap["timeouts"].(int)
+		}
+
+		return unhealthy
+	}
+	return nil
+}
+
+func createKongPassiveHealthyFromMap(data *map[string]interface{}) *gokong.PassiveHealthy {
+	if data != nil {
+		dataMap := *data
+		healthy := &gokong.PassiveHealthy{}
+
+		if dataMap["http_statuses"] != nil {
+			healthy.HttpStatuses = readIntArrayFromInterface(dataMap["http_statuses"])
+		}
+		if dataMap["successes"] != nil {
+			healthy.Successes = dataMap["successes"].(int)
+		}
+
+		return healthy
+	}
+	return nil
+}
+
+func createKongPassiveUnhealthyFromMap(data *map[string]interface{}) *gokong.PassiveUnhealthy {
+	if data != nil {
+		dataMap := *data
+		unhealthy := &gokong.PassiveUnhealthy{}
+
+		if dataMap["http_statuses"] != nil {
+			unhealthy.HttpStatuses = readIntArrayFromInterface(dataMap["http_statuses"])
+		}
+		if dataMap["tcp_failures"] != nil {
+			unhealthy.TcpFailures = dataMap["tcp_failures"].(int)
+		}
+		if dataMap["http_failures"] != nil {
+			unhealthy.HttpFailures = dataMap["http_failures"].(int)
+		}
+		if dataMap["timeouts"] != nil {
+			unhealthy.Timeouts = dataMap["timeouts"].(int)
+		}
+
+		return unhealthy
+	}
+	return nil
+}
+
+func flattenHealthCheck(in *gokong.UpstreamHealthCheck) []interface{} {
+	if in == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if in.Active != nil {
+		m["active"] = flattenHealthCheckActive(in.Active)
+	}
+	if in.Passive != nil {
+		m["passive"] = flattenHealthCheckPassive(in.Passive)
+	}
+
+	return []interface{}{m}
+}
+
+func flattenHealthCheckActive(in *gokong.UpstreamHealthCheckActive) []interface{} {
+	if in == nil {
+		return []interface{}{}
+	}
+	m := make(map[string]interface{})
+
+	m["timeout"] = in.Timeout
+	m["concurrency"] = in.Concurrency
+	m["http_path"] = in.HttpPath
+
+	if in.Healthy != nil {
+		m["healthy"] = flattenActiveHealthy(in.Healthy)
+	}
+	if in.Unhealthy != nil {
+		m["unhealthy"] = flattenActiveUnhealthy(in.Unhealthy)
+	}
+
+	return []interface{}{m}
+}
+
+func flattenHealthCheckPassive(in *gokong.UpstreamHealthCheckPassive) []interface{} {
+	if in == nil {
+		return []interface{}{}
+	}
+
+	m := make(map[string]interface{})
+
+	if in.Healthy != nil {
+		m["healthy"] = flattenPassiveHealthy(in.Healthy)
+	}
+	if in.Unhealthy != nil {
+		m["unhealthy"] = flattenPassiveUnhealthy(in.Unhealthy)
+	}
+
+	return []interface{}{m}
+}
+
+func flattenActiveHealthy(in *gokong.ActiveHealthy) []map[string]interface{} {
+	if in == nil {
+		return []map[string]interface{}{}
+	}
+	m := make(map[string]interface{})
+
+	m["interval"] = in.Interval
+	m["http_statuses"] = in.HttpStatuses
+	m["successes"] = in.Successes
+
+	return []map[string]interface{}{m}
+}
+
+func flattenActiveUnhealthy(in *gokong.ActiveUnhealthy) []map[string]interface{} {
+	if in == nil {
+		return []map[string]interface{}{}
+	}
+	m := make(map[string]interface{})
+
+	m["interval"] = in.Interval
+	m["http_statuses"] = in.HttpStatuses
+	m["tcp_failures"] = in.TcpFailures
+	m["http_failures"] = in.HttpFailures
+	m["timeouts"] = in.Timeouts
+
+	return []map[string]interface{}{m}
+}
+
+func flattenPassiveHealthy(in *gokong.PassiveHealthy) []map[string]interface{} {
+	if in == nil {
+		return []map[string]interface{}{}
+	}
+	m := make(map[string]interface{})
+
+	m["http_statuses"] = in.HttpStatuses
+	m["successes"] = in.Successes
+
+	return []map[string]interface{}{m}
+}
+
+func flattenPassiveUnhealthy(in *gokong.PassiveUnhealthy) []map[string]interface{} {
+	if in == nil {
+		return []map[string]interface{}{}
+	}
+	m := make(map[string]interface{})
+
+	m["http_statuses"] = in.HttpStatuses
+	m["tcp_failures"] = in.TcpFailures
+	m["http_failures"] = in.HttpFailures
+	m["timeouts"] = in.Timeouts
+
+	return []map[string]interface{}{m}
 }

--- a/kong/resource_kong_upstream_test.go
+++ b/kong/resource_kong_upstream_test.go
@@ -2,6 +2,7 @@ package kong
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -21,6 +22,56 @@ func TestAccKongUpstream(t *testing.T) {
 					testAccCheckKongUpstreamExists("kong_upstream.upstream"),
 					resource.TestCheckResourceAttr("kong_upstream.upstream", "name", "MyUpstream"),
 					resource.TestCheckResourceAttr("kong_upstream.upstream", "slots", "10"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "hash_on", "none"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "hash_fallback", "none"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "hash_on_header", ""),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "hash_fallback_header", ""),
+
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.timeout", "1"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.concurrency", "10"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.http_path", "/"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.healthy.0.interval", "0"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.healthy.0.successes", "0"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.healthy.0.http_statuses.0", "200"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.healthy.0.http_statuses.1", "302"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.interval", "0"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.tcp_failures", "0"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.http_failures", "0"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.timeouts", "0"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.http_statuses.0", "429"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.http_statuses.1", "404"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.http_statuses.2", "500"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.http_statuses.3", "501"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.http_statuses.4", "502"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.http_statuses.5", "503"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.http_statuses.6", "504"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.http_statuses.7", "505"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.successes", "0"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.0", "200"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.1", "201"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.2", "202"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.3", "203"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.4", "204"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.5", "205"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.6", "206"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.7", "207"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.8", "208"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.9", "226"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.10", "300"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.11", "301"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.12", "302"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.13", "303"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.14", "304"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.15", "305"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.16", "306"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.17", "307"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.18", "308"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.unhealthy.0.tcp_failures", "0"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.unhealthy.0.http_failures", "0"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.unhealthy.0.timeouts", "0"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.unhealthy.0.http_statuses.0", "429"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.unhealthy.0.http_statuses.1", "500"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.unhealthy.0.http_statuses.2", "503"),
 				),
 			},
 			{
@@ -29,6 +80,34 @@ func TestAccKongUpstream(t *testing.T) {
 					testAccCheckKongUpstreamExists("kong_upstream.upstream"),
 					resource.TestCheckResourceAttr("kong_upstream.upstream", "name", "MyUpstream"),
 					resource.TestCheckResourceAttr("kong_upstream.upstream", "slots", "20"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "hash_on", "header"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "hash_fallback", "consumer"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "hash_on_header", "HeaderName"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "hash_fallback_header", "FallbackHeaderName"),
+
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.timeout", "10"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.concurrency", "20"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.http_path", "/status"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.healthy.0.interval", "5"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.healthy.0.successes", "1"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.healthy.0.http_statuses.0", "200"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.healthy.0.http_statuses.1", "201"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.interval", "3"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.tcp_failures", "1"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.http_failures", "2"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.timeouts", "7"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.http_statuses.0", "500"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.active.0.unhealthy.0.http_statuses.1", "501"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.successes", "1"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.0", "200"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.1", "201"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.healthy.0.http_statuses.2", "202"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.unhealthy.0.tcp_failures", "5"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.unhealthy.0.http_failures", "6"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.unhealthy.0.timeouts", "3"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.unhealthy.0.http_statuses.0", "500"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.unhealthy.0.http_statuses.1", "501"),
+					resource.TestCheckResourceAttr("kong_upstream.upstream", "healthchecks.0.passive.0.unhealthy.0.http_statuses.2", "502"),
 				),
 			},
 		},
@@ -103,6 +182,802 @@ func testAccCheckKongUpstreamExists(resourceKey string) resource.TestCheckFunc {
 	}
 }
 
+func TestCreateKongHealthCheckFromMap(t *testing.T) {
+	cases := []struct {
+		in       *map[string]interface{}
+		expected *gokong.UpstreamHealthCheck
+	}{
+		// Empty data
+		{
+			in:       &map[string]interface{}{},
+			expected: &gokong.UpstreamHealthCheck{},
+		}, // Simple data
+		{
+			in: &map[string]interface{}{},
+			expected: &gokong.UpstreamHealthCheck{
+				Active:  nil,
+				Passive: nil,
+			},
+		}, // All data
+		{
+			in: &map[string]interface{}{
+				"active": []interface{}{
+					map[string]interface{}{
+						"concurrency": 12,
+						"http_path":   "/health",
+						"timeout":     60,
+					},
+				},
+				"passive": []interface{}{
+					map[string]interface{}{},
+				},
+			},
+			expected: &gokong.UpstreamHealthCheck{
+				Active: &gokong.UpstreamHealthCheckActive{
+					Concurrency: 12,
+					Healthy:     nil,
+					HttpPath:    "/health",
+					Timeout:     60,
+					Unhealthy:   nil,
+				},
+				Passive: &gokong.UpstreamHealthCheckPassive{
+					Healthy:   nil,
+					Unhealthy: nil,
+				},
+			},
+		},
+		{
+			in:       nil,
+			expected: nil,
+		},
+	}
+
+	for _, c := range cases {
+		out := createKongHealthCheckFromMap(c.in)
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
+
+func TestCreateKongHealthCheckActiveFromMap(t *testing.T) {
+	cases := []struct {
+		in       *map[string]interface{}
+		expected *gokong.UpstreamHealthCheckActive
+	}{
+		// Empty data
+		{
+			in:       &map[string]interface{}{},
+			expected: &gokong.UpstreamHealthCheckActive{},
+		}, // Simple data
+		{
+			in: &map[string]interface{}{
+				"concurrency": 12,
+				"http_path":   "/health",
+				"timeout":     60,
+			},
+			expected: &gokong.UpstreamHealthCheckActive{
+				Concurrency: 12,
+				Healthy:     nil,
+				HttpPath:    "/health",
+				Timeout:     60,
+				Unhealthy:   nil,
+			},
+		}, // All data
+		{
+			in: &map[string]interface{}{
+				"concurrency": 12,
+				"http_path":   "/health",
+				"timeout":     60,
+				"healthy": []interface{}{
+					map[string]interface{}{
+						"successes":     3,
+						"interval":      5,
+						"http_statuses": []interface{}{200},
+					},
+				},
+				"unhealthy": []interface{}{
+					map[string]interface{}{
+						"http_failures": 1,
+						"http_statuses": []interface{}{500},
+						"interval":      5,
+						"tcp_failures":  2,
+						"timeouts":      4,
+					},
+				},
+			},
+			expected: &gokong.UpstreamHealthCheckActive{
+				Concurrency: 12,
+				Healthy: &gokong.ActiveHealthy{
+					Successes:    3,
+					Interval:     5,
+					HttpStatuses: []int{200},
+				},
+				HttpPath: "/health",
+				Timeout:  60,
+				Unhealthy: &gokong.ActiveUnhealthy{
+					HttpFailures: 1,
+					HttpStatuses: []int{500},
+					Interval:     5,
+					TcpFailures:  2,
+					Timeouts:     4,
+				},
+			},
+		},
+		{
+			in:       nil,
+			expected: nil,
+		},
+	}
+
+	for _, c := range cases {
+		out := createKongHealthCheckActiveFromMap(c.in)
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
+
+func TestCreateKongHealthCheckPassiveFromMap(t *testing.T) {
+	cases := []struct {
+		in       *map[string]interface{}
+		expected *gokong.UpstreamHealthCheckPassive
+	}{
+		// Empty data
+		{
+			in:       &map[string]interface{}{},
+			expected: &gokong.UpstreamHealthCheckPassive{},
+		}, // Simple data
+		{
+			in: &map[string]interface{}{},
+			expected: &gokong.UpstreamHealthCheckPassive{
+				Healthy:   nil,
+				Unhealthy: nil,
+			},
+		}, // All data
+		{
+			in: &map[string]interface{}{
+				"healthy": []interface{}{
+					map[string]interface{}{
+						"successes":     3,
+						"http_statuses": []interface{}{200},
+					},
+				},
+				"unhealthy": []interface{}{
+					map[string]interface{}{
+						"http_failures": 1,
+						"http_statuses": []interface{}{500},
+						"tcp_failures":  2,
+						"timeouts":      4,
+					},
+				},
+			},
+			expected: &gokong.UpstreamHealthCheckPassive{
+				Healthy: &gokong.PassiveHealthy{
+					Successes:    3,
+					HttpStatuses: []int{200},
+				},
+				Unhealthy: &gokong.PassiveUnhealthy{
+					HttpFailures: 1,
+					HttpStatuses: []int{500},
+					TcpFailures:  2,
+					Timeouts:     4,
+				},
+			},
+		},
+		{
+			in:       nil,
+			expected: nil,
+		},
+	}
+
+	for _, c := range cases {
+		out := createKongHealthCheckPassiveFromMap(c.in)
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
+
+func TestCreateKongActiveHealthyFromMap(t *testing.T) {
+	cases := []struct {
+		in       *map[string]interface{}
+		expected *gokong.ActiveHealthy
+	}{
+		// Empty data
+		{
+			in:       &map[string]interface{}{},
+			expected: &gokong.ActiveHealthy{},
+		}, // Simple data
+		{
+			in: &map[string]interface{}{
+				"interval":      3,
+				"http_statuses": []interface{}{200},
+				"successes":     2,
+			},
+			expected: &gokong.ActiveHealthy{
+				HttpStatuses: []int{200},
+				Interval:     3,
+				Successes:    2,
+			},
+		}, // EmptyHttpStatuses
+		{
+			in: &map[string]interface{}{
+				"interval":      3,
+				"http_statuses": []interface{}{},
+				"successes":     2,
+			},
+			expected: &gokong.ActiveHealthy{
+				HttpStatuses: []int{},
+				Interval:     3,
+				Successes:    2,
+			},
+		},
+		{
+			in:       nil,
+			expected: nil,
+		},
+	}
+
+	for _, c := range cases {
+		out := createKongActiveHealthyFromMap(c.in)
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
+
+func TestCreateKongActiveUnhealthyFromMap(t *testing.T) {
+	cases := []struct {
+		in       *map[string]interface{}
+		expected *gokong.ActiveUnhealthy
+	}{
+		// Empty data
+		{
+			in:       &map[string]interface{}{},
+			expected: &gokong.ActiveUnhealthy{},
+		}, // Simple data
+		{
+			in: &map[string]interface{}{
+				"http_failures": 4,
+				"http_statuses": []interface{}{200},
+				"interval":      3,
+				"tcp_failures":  5,
+				"timeouts":      6,
+			},
+			expected: &gokong.ActiveUnhealthy{
+				HttpFailures: 4,
+				HttpStatuses: []int{200},
+				Interval:     3,
+				TcpFailures:  5,
+				Timeouts:     6,
+			},
+		}, // EmptyHttpStatuses
+		{
+			in: &map[string]interface{}{
+				"http_failures": 4,
+				"http_statuses": []interface{}{},
+				"interval":      3,
+				"tcp_failures":  5,
+				"timeouts":      6,
+			},
+			expected: &gokong.ActiveUnhealthy{
+				HttpFailures: 4,
+				HttpStatuses: []int{},
+				Interval:     3,
+				TcpFailures:  5,
+				Timeouts:     6,
+			},
+		},
+		{
+			in:       nil,
+			expected: nil,
+		},
+	}
+
+	for _, c := range cases {
+		out := createKongActiveUnhealthyFromMap(c.in)
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
+
+func TestCreateKongPassiveHealthyFromMap(t *testing.T) {
+	cases := []struct {
+		in       *map[string]interface{}
+		expected *gokong.PassiveHealthy
+	}{
+		// Empty data
+		{
+			in:       &map[string]interface{}{},
+			expected: &gokong.PassiveHealthy{},
+		}, // Simple data
+		{
+			in: &map[string]interface{}{
+				"http_statuses": []interface{}{
+					200,
+				},
+				"successes": 3,
+			},
+			expected: &gokong.PassiveHealthy{
+				HttpStatuses: []int{200},
+				Successes:    3,
+			},
+		}, // EmptyHttpStatuses
+		{
+			in: &map[string]interface{}{
+				"http_statuses": []interface{}{},
+				"successes":     3,
+			},
+			expected: &gokong.PassiveHealthy{
+				HttpStatuses: []int{},
+				Successes:    3,
+			},
+		},
+		{
+			in:       nil,
+			expected: nil,
+		},
+	}
+
+	for _, c := range cases {
+		out := createKongPassiveHealthyFromMap(c.in)
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
+
+func TestCreateKongPassiveUnhealthyFromMap(t *testing.T) {
+	cases := []struct {
+		in       *map[string]interface{}
+		expected *gokong.PassiveUnhealthy
+	}{
+		// Empty data
+		{
+			in:       &map[string]interface{}{},
+			expected: &gokong.PassiveUnhealthy{},
+		}, // Simple data
+		{
+			in: &map[string]interface{}{
+				"http_statuses": []interface{}{200},
+				"tcp_failures":  3,
+				"http_failures": 4,
+				"timeouts":      5,
+			},
+			expected: &gokong.PassiveUnhealthy{
+				HttpStatuses: []int{200},
+				TcpFailures:  3,
+				HttpFailures: 4,
+				Timeouts:     5,
+			},
+		}, // EmptyHttpStatuses
+		{
+			in: &map[string]interface{}{
+				"http_statuses": []interface{}{},
+				"tcp_failures":  3,
+				"http_failures": 4,
+				"timeouts":      5,
+			},
+			expected: &gokong.PassiveUnhealthy{
+				HttpStatuses: []int{},
+				TcpFailures:  3,
+				HttpFailures: 4,
+				Timeouts:     5,
+			},
+		},
+		{
+			in:       nil,
+			expected: nil,
+		},
+	}
+
+	for _, c := range cases {
+		out := createKongPassiveUnhealthyFromMap(c.in)
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
+
+func TestFlattenHealthCheck(t *testing.T) {
+	cases := []struct {
+		in       *gokong.UpstreamHealthCheck
+		expected []interface{}
+	}{
+		// Simple data
+		{
+			in: &gokong.UpstreamHealthCheck{
+				Active:  nil,
+				Passive: nil,
+			},
+			expected: []interface{}{
+				map[string]interface{}{},
+			},
+		}, // All data
+		{
+			in: &gokong.UpstreamHealthCheck{
+				Active: &gokong.UpstreamHealthCheckActive{
+					Concurrency: 12,
+					Healthy:     nil,
+					HttpPath:    "/health",
+					Timeout:     60,
+					Unhealthy:   nil,
+				},
+				Passive: &gokong.UpstreamHealthCheckPassive{
+					Healthy:   nil,
+					Unhealthy: nil,
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"active": []interface{}{
+						map[string]interface{}{
+							"concurrency": 12,
+							"http_path":   "/health",
+							"timeout":     60,
+						},
+					},
+					"passive": []interface{}{
+						map[string]interface{}{},
+					},
+				},
+			},
+		}, // Nil object
+		{
+			in:       nil,
+			expected: []interface{}{},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenHealthCheck(c.in)
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
+
+func TestFlattenHealthCheckActive(t *testing.T) {
+	cases := []struct {
+		in       *gokong.UpstreamHealthCheckActive
+		expected []interface{}
+	}{
+		// Simple data
+		{
+			in: &gokong.UpstreamHealthCheckActive{
+				Concurrency: 12,
+				Healthy:     nil,
+				HttpPath:    "/health",
+				Timeout:     60,
+				Unhealthy:   nil,
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"concurrency": 12,
+					"http_path":   "/health",
+					"timeout":     60,
+				},
+			},
+		}, // All data
+		{
+			in: &gokong.UpstreamHealthCheckActive{
+				Concurrency: 12,
+				Healthy: &gokong.ActiveHealthy{
+					Successes:    3,
+					Interval:     5,
+					HttpStatuses: []int{200},
+				},
+				HttpPath: "/health",
+				Timeout:  60,
+				Unhealthy: &gokong.ActiveUnhealthy{
+					HttpFailures: 1,
+					HttpStatuses: []int{500},
+					Interval:     5,
+					TcpFailures:  2,
+					Timeouts:     4,
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"concurrency": 12,
+					"http_path":   "/health",
+					"timeout":     60,
+					"healthy": []map[string]interface{}{
+						{
+							"successes":     3,
+							"interval":      5,
+							"http_statuses": []int{200},
+						},
+					},
+					"unhealthy": []map[string]interface{}{
+						{
+							"http_failures": 1,
+							"http_statuses": []int{500},
+							"interval":      5,
+							"tcp_failures":  2,
+							"timeouts":      4,
+						},
+					},
+				},
+			},
+		}, // Nil object
+		{
+			in:       nil,
+			expected: []interface{}{},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenHealthCheckActive(c.in)
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
+
+func TestFlattenHealthCheckPassive(t *testing.T) {
+	cases := []struct {
+		in       *gokong.UpstreamHealthCheckPassive
+		expected []interface{}
+	}{
+		// Simple data
+		{
+			in: &gokong.UpstreamHealthCheckPassive{
+				Healthy:   nil,
+				Unhealthy: nil,
+			},
+			expected: []interface{}{
+				map[string]interface{}{},
+			},
+		}, // All data
+		{
+			in: &gokong.UpstreamHealthCheckPassive{
+				Healthy: &gokong.PassiveHealthy{
+					Successes:    3,
+					HttpStatuses: []int{200},
+				},
+				Unhealthy: &gokong.PassiveUnhealthy{
+					HttpFailures: 1,
+					HttpStatuses: []int{500},
+					TcpFailures:  2,
+					Timeouts:     4,
+				},
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"healthy": []map[string]interface{}{
+						{
+							"successes":     3,
+							"http_statuses": []int{200},
+						},
+					},
+					"unhealthy": []map[string]interface{}{
+						{
+							"http_failures": 1,
+							"http_statuses": []int{500},
+							"tcp_failures":  2,
+							"timeouts":      4,
+						},
+					},
+				},
+			},
+		}, // Nil object
+		{
+			in:       nil,
+			expected: []interface{}{},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenHealthCheckPassive(c.in)
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
+
+func TestFlattenActiveHealthy(t *testing.T) {
+	cases := []struct {
+		in       *gokong.ActiveHealthy
+		expected []map[string]interface{}
+	}{
+		// Simple, all data
+		{
+			in: &gokong.ActiveHealthy{
+				HttpStatuses: []int{200},
+				Interval:     3,
+				Successes:    2,
+			},
+			expected: []map[string]interface{}{
+				{
+					"interval":      3,
+					"http_statuses": []int{200},
+					"successes":     2,
+				},
+			},
+		}, // EmptyHttpStatuses
+		{
+			in: &gokong.ActiveHealthy{
+				HttpStatuses: []int{},
+				Interval:     3,
+				Successes:    2,
+			},
+			expected: []map[string]interface{}{
+				{
+					"interval":      3,
+					"http_statuses": []int{},
+					"successes":     2,
+				},
+			},
+		}, // Nil object
+		{
+			in:       nil,
+			expected: []map[string]interface{}{},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenActiveHealthy(c.in)
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
+
+func TestFlattenActiveUnhealthy(t *testing.T) {
+	cases := []struct {
+		in       *gokong.ActiveUnhealthy
+		expected []map[string]interface{}
+	}{
+		// Simple, all data
+		{
+			in: &gokong.ActiveUnhealthy{
+				HttpFailures: 4,
+				HttpStatuses: []int{200},
+				Interval:     3,
+				TcpFailures:  5,
+				Timeouts:     6,
+			},
+			expected: []map[string]interface{}{
+				{
+					"http_failures": 4,
+					"http_statuses": []int{200},
+					"interval":      3,
+					"tcp_failures":  5,
+					"timeouts":      6,
+				},
+			},
+		}, // EmptyHttpStatuses
+		{
+			in: &gokong.ActiveUnhealthy{
+				HttpFailures: 4,
+				HttpStatuses: []int{},
+				Interval:     3,
+				TcpFailures:  5,
+				Timeouts:     6,
+			},
+			expected: []map[string]interface{}{
+				{
+					"http_failures": 4,
+					"http_statuses": []int{},
+					"interval":      3,
+					"tcp_failures":  5,
+					"timeouts":      6,
+				},
+			},
+		}, // Nil object
+		{
+			in:       nil,
+			expected: []map[string]interface{}{},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenActiveUnhealthy(c.in)
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
+
+func TestFlattenPassiveHealthy(t *testing.T) {
+	cases := []struct {
+		in       *gokong.PassiveHealthy
+		expected []map[string]interface{}
+	}{
+		// Simple, all data
+		{
+			in: &gokong.PassiveHealthy{
+				HttpStatuses: []int{200},
+				Successes:    3,
+			},
+			expected: []map[string]interface{}{
+				{
+					"http_statuses": []int{200},
+					"successes":     3,
+				},
+			},
+		}, // EmptyHttpStatuses
+		{
+			in: &gokong.PassiveHealthy{
+				HttpStatuses: []int{},
+				Successes:    3,
+			},
+			expected: []map[string]interface{}{
+				{
+					"http_statuses": []int{},
+					"successes":     3,
+				},
+			},
+		}, // Nil object
+		{
+			in:       nil,
+			expected: []map[string]interface{}{},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenPassiveHealthy(c.in)
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
+
+func TestFlattenPassiveUnhealthy(t *testing.T) {
+	cases := []struct {
+		in       *gokong.PassiveUnhealthy
+		expected []map[string]interface{}
+	}{
+		// Simple, all data
+		{
+			in: &gokong.PassiveUnhealthy{
+				HttpStatuses: []int{200},
+				TcpFailures:  3,
+				HttpFailures: 4,
+				Timeouts:     5,
+			},
+			expected: []map[string]interface{}{
+				{
+					"http_statuses": []int{200},
+					"tcp_failures":  3,
+					"http_failures": 4,
+					"timeouts":      5,
+				},
+			},
+		}, // EmptyHttpStatuses
+		{
+			in: &gokong.PassiveUnhealthy{
+				HttpStatuses: []int{},
+				TcpFailures:  3,
+				HttpFailures: 4,
+				Timeouts:     5,
+			},
+			expected: []map[string]interface{}{
+				{
+					"http_statuses": []int{},
+					"tcp_failures":  3,
+					"http_failures": 4,
+					"timeouts":      5,
+				},
+			},
+		}, // Nil object
+		{
+			in:       nil,
+			expected: []map[string]interface{}{},
+		},
+	}
+
+	for _, c := range cases {
+		out := flattenPassiveUnhealthy(c.in)
+		if !reflect.DeepEqual(out, c.expected) {
+			t.Fatalf("Error matching output and expected: %#v vs %#v", out, c.expected)
+		}
+	}
+}
+
 const testCreateUpstreamConfig = `
 resource "kong_upstream" "upstream" {
 	name  		= "MyUpstream"
@@ -111,7 +986,42 @@ resource "kong_upstream" "upstream" {
 `
 const testUpdateUpstreamConfig = `
 resource "kong_upstream" "upstream" {
-	name  		= "MyUpstream"
-	slots 		= 20
+	name  		         = "MyUpstream"
+	slots 		         = 20
+	hash_on              = "header"
+	hash_fallback        = "consumer"
+	hash_on_header       = "HeaderName"
+	hash_fallback_header = "FallbackHeaderName"
+	healthchecks         = {
+		active = {
+			http_path                = "/status"
+			timeout                  = 10
+			concurrency              = 20
+			healthy = {
+				successes = 1
+				interval  = 5
+				http_statuses = [200, 201]
+			}
+			unhealthy = {
+				timeouts      = 7
+				interval      = 3
+				tcp_failures  = 1
+				http_failures = 2
+				http_statuses = [500, 501]
+			}
+		}
+		passive = {
+			healthy = {
+				successes = 1
+				http_statuses = [200, 201, 202]
+			}
+			unhealthy = {
+				timeouts      = 3
+				tcp_failures  = 5
+				http_failures = 6
+				http_statuses = [500, 501, 502]
+			}
+		}
+	}
 }
 `

--- a/kong/resource_reader.go
+++ b/kong/resource_reader.go
@@ -53,6 +53,14 @@ func readIntArrayFromResource(d *schema.ResourceData, key string) []int {
 	return nil
 }
 
+func readArrayFromResource(d *schema.ResourceData, key string) []interface{} {
+	if attr, ok := d.GetOk(key); ok {
+		return attr.([]interface{})
+	}
+
+	return nil
+}
+
 func readStringFromResource(d *schema.ResourceData, key string) string {
 	if attr, ok := d.GetOk(key); ok {
 		return attr.(string)

--- a/kong/testing.go
+++ b/kong/testing.go
@@ -17,3 +17,7 @@ func getResourcesByType(resourceType string, state *terraform.State) []*terrafor
 
 	return result
 }
+
+func String(v string) *string {
+	return &v
+}

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -11,3 +11,17 @@ func contains(s []string, e string) bool {
 
 	return false
 }
+
+func readIntArrayFromInterface(in interface{}) []int {
+	if arr := in.([]interface{}); arr != nil {
+		array := make([]int, len(arr))
+		for i, x := range arr {
+			item := x.(int)
+			array[i] = item
+		}
+
+		return array
+	}
+
+	return []int{}
+}

--- a/vendor/github.com/kevholditch/gokong/client.go
+++ b/vendor/github.com/kevholditch/gokong/client.go
@@ -139,6 +139,12 @@ func (kongAdminClient *KongAdminClient) Routes() *RouteClient {
 	}
 }
 
+func (kongAdminClient *KongAdminClient) Targets() *TargetClient {
+	return &TargetClient{
+		config: kongAdminClient.config,
+	}
+}
+
 func (kongAdminClient *KongAdminClient) Services() *ServiceClient {
 	return &ServiceClient{
 		config: kongAdminClient.config,

--- a/vendor/github.com/kevholditch/gokong/targets.go
+++ b/vendor/github.com/kevholditch/gokong/targets.go
@@ -1,0 +1,202 @@
+package gokong
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type TargetClient struct {
+	config *Config
+}
+
+type TargetRequest struct {
+	Target string `json:"target"`
+	Weight int    `json:"weight"`
+}
+
+type Target struct {
+	Id        *string  `json:"id,omitempty"`
+	CreatedAt *float32 `json:"created_at"`
+	Target    *string  `json:"target"`
+	Weight    *int     `json:"weight"`
+	Upstream  *string  `json:"upstream_id"`
+	Health    *string  `json:"health"`
+}
+
+type Targets struct {
+	Data   []*Target `json:"data"`
+	Total  int       `json:"total,omitempty"`
+	Next   string    `json:"next,omitempty"`
+	NodeId string    `json:"node_id,omitempty"`
+}
+
+const TargetsPath = "/upstreams/%s/targets"
+
+func (targetClient *TargetClient) CreateFromUpstreamName(name string, targetRequest *TargetRequest) (*Target, error) {
+	return targetClient.CreateFromUpstreamId(name, targetRequest)
+}
+
+func (targetClient *TargetClient) CreateFromUpstreamId(id string, targetRequest *TargetRequest) (*Target, error) {
+	r, body, errs := newPost(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, id)).Send(targetRequest).End()
+	if errs != nil {
+		return nil, fmt.Errorf("could not register the target, error: %v", errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	createdTarget := &Target{}
+	err := json.Unmarshal([]byte(body), createdTarget)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse target get response, error: %v", err)
+	}
+
+	if createdTarget.Id == nil {
+		return nil, fmt.Errorf("could not register the target, error: %v", body)
+	}
+
+	return createdTarget, nil
+}
+
+func (targetClient *TargetClient) GetTargetsFromUpstreamName(name string) ([]*Target, error) {
+	return targetClient.GetTargetsFromUpstreamId(name)
+}
+
+func (targetClient *TargetClient) GetTargetsFromUpstreamId(id string) ([]*Target, error) {
+	targets := []*Target{}
+	data := &Targets{}
+
+	for {
+		r, body, errs := newGet(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, id)).End()
+		if errs != nil {
+			return nil, fmt.Errorf("could not get targets, error: %v", errs)
+		}
+
+		if r.StatusCode == 401 || r.StatusCode == 403 {
+			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+		}
+
+		if r.StatusCode == 404 {
+			return nil, fmt.Errorf("non existent upstream: %s", id)
+		}
+
+		err := json.Unmarshal([]byte(body), data)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse target get response, error: %v", err)
+		}
+
+		targets = append(targets, data.Data...)
+
+		if data.Next == "" {
+			break
+		}
+	}
+	return targets, nil
+}
+
+func (targetClient *TargetClient) DeleteFromUpstreamByHostPort(upstreamNameOrId string, hostPort string) error {
+	return targetClient.DeleteFromUpstreamById(upstreamNameOrId, hostPort)
+}
+
+func (targetClient *TargetClient) DeleteFromUpstreamById(upstreamNameOrId string, id string) error {
+	r, body, errs := newDelete(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, upstreamNameOrId)+fmt.Sprintf("/%s", id)).End()
+	if errs != nil {
+		return fmt.Errorf("could not delete the target, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode != 204 {
+		return fmt.Errorf("Received unexpected response status code: %d. Body: %s", r.StatusCode, body)
+	}
+
+	return nil
+}
+
+func (targetClient *TargetClient) SetTargetFromUpstreamByHostPortAsHealthy(upstreamNameOrId string, hostPort string) error {
+	return targetClient.SetTargetFromUpstreamByIdAsHealthy(upstreamNameOrId, hostPort)
+}
+
+func (targetClient *TargetClient) SetTargetFromUpstreamByIdAsHealthy(upstreamNameOrId string, id string) error {
+	r, body, errs := newPost(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, upstreamNameOrId)+fmt.Sprintf("/%s/healthy", id)).Send("").End()
+	if errs != nil {
+		return fmt.Errorf("could not set the target as healthy, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode != 204 {
+		return fmt.Errorf("Received unexpected response status code: %d. Body: %s", r.StatusCode, body)
+	}
+
+	return nil
+}
+
+func (targetClient *TargetClient) SetTargetFromUpstreamByHostPortAsUnhealthy(upstreamNameOrId string, hostPort string) error {
+	return targetClient.SetTargetFromUpstreamByIdAsUnhealthy(upstreamNameOrId, hostPort)
+}
+
+func (targetClient *TargetClient) SetTargetFromUpstreamByIdAsUnhealthy(upstreamNameOrId string, id string) error {
+	r, body, errs := newPost(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf(TargetsPath, upstreamNameOrId)+fmt.Sprintf("/%s/unhealthy", id)).Send("").End()
+	if errs != nil {
+		return fmt.Errorf("could not set the target as unhealthy, result: %v error: %v", r, errs)
+	}
+
+	if r.StatusCode == 401 || r.StatusCode == 403 {
+		return fmt.Errorf("not authorised, message from kong: %s", body)
+	}
+
+	if r.StatusCode != 204 {
+		return fmt.Errorf("Received unexpected response status code: %d. Body: %s", r.StatusCode, body)
+	}
+
+	return nil
+}
+
+func (targetClient *TargetClient) GetTargetsWithHealthFromUpstreamName(name string) ([]*Target, error) {
+	return targetClient.GetTargetsWithHealthFromUpstreamId(name)
+}
+
+func (targetClient *TargetClient) GetTargetsWithHealthFromUpstreamId(id string) ([]*Target, error) {
+	targets := []*Target{}
+	data := &Targets{}
+
+	for {
+		r, body, errs := newGet(targetClient.config, targetClient.config.HostAddress+fmt.Sprintf("/upstreams/%s/health", id)).End()
+		if errs != nil {
+			return nil, fmt.Errorf("could not get targets, error: %v", errs)
+		}
+
+		if r.StatusCode == 401 || r.StatusCode == 403 {
+			return nil, fmt.Errorf("not authorised, message from kong: %s", body)
+		}
+
+		if r.StatusCode == 404 {
+			return nil, fmt.Errorf("non existent upstream: %s", id)
+		}
+
+		err := json.Unmarshal([]byte(body), data)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse target get response, error: %v", err)
+		}
+
+		targets = append(targets, data.Data...)
+
+		if data.Next == "" {
+			break
+		}
+	}
+	return targets, nil
+}
+
+// TODO: Implement List all Targets - https://docs.konghq.com/1.0.x/admin-api/#list-all-targets
+// Note: JSON returned by this method has slightly different structure to the standard Get request. This method retruns "upstream_id": "07131005-ba30-4204-a29f-0927d53257b4" instead of "upstream": {"id":"127dfc88-ed57-45bf-b77a-a9d3a152ad31"},
+
+// TODO: Implement other methods available by /targets paths
+// https://docs.konghq.com/1.0.x/admin-api/#update-or-create-upstream
+// https://docs.konghq.com/1.0.x/admin-api/#delete-upstream

--- a/vendor/github.com/kevholditch/gokong/upstreams.go
+++ b/vendor/github.com/kevholditch/gokong/upstreams.go
@@ -25,11 +25,11 @@ type UpstreamHealthCheck struct {
 }
 
 type UpstreamHealthCheckActive struct {
-	Concurrency int              `json:"concurrency,omitempty"`
-	Healthy     *ActiveHealthy   `json:"healthy,omitempty"`
-	HttpPath    string           `json:"http_path,omitempty"`
-	Timeout     int              `json:"timeout,omitempty"`
-	Unhealthy   *ActiveUnhealthy `json:"unhealthy,omitempty"`
+	Concurrency            int              `json:"concurrency,omitempty"`
+	Healthy                *ActiveHealthy   `json:"healthy,omitempty"`
+	HttpPath               string           `json:"http_path,omitempty"`
+	Timeout                int              `json:"timeout,omitempty"`
+	Unhealthy              *ActiveUnhealthy `json:"unhealthy,omitempty"`
 }
 
 type ActiveHealthy struct {


### PR DESCRIPTION
Since Kong Enterprise is still based on Kong 0.13.x I've added support for Upstreams and Targets. The work is based on changes from `master` branch.