### PR TITLE
Make resource of certificate attributes to sensitive

### DIFF
--- a/kong/resource_kong_certificate.go
+++ b/kong/resource_kong_certificate.go
@@ -22,7 +22,7 @@ func resourceKongCertificate() *schema.Resource {
 				Type:      schema.TypeString,
 				Required:  true,
 				ForceNew:  false,
-				Sensitive: true,
+				Sensitive: false,
 			},
 			"private_key": &schema.Schema{
 				Type:      schema.TypeString,

--- a/kong/resource_kong_certificate.go
+++ b/kong/resource_kong_certificate.go
@@ -19,14 +19,16 @@ func resourceKongCertificate() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"certificate": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: false,
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  false,
+				Sensitive: true,
 			},
 			"private_key": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: false,
+				Type:      schema.TypeString,
+				Optional:  true,
+				ForceNew:  false,
+				Sensitive: true,
 			},
 		},
 	}


### PR DESCRIPTION
By default, we should set the certificate to sensitive to avoid the output causing security policy concerns, Issued by https://github.com/kevholditch/terraform-provider-kong/issues/65