### PR TITLE
Improved plugins handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ after_success:
 - make release
 env:
   matrix:
-    - KONG_VERSION=1.0.0  TF_ACC=1
+    - KONG_VERSION=1.4.2  TF_ACC=1
     - KONG_VERSION=1.0.2  TF_ACC=1
   global:
     - GO111MODULE=on

--- a/README.md
+++ b/README.md
@@ -46,14 +46,15 @@ provider "kong" {
 
 You can use environment variables to set the provider properties instead.  The following table shows all of the config options, the corresponding environment variables and their property defaults if you do not set them.  When using the `kong_api_key` parameter ensure that the key name parameter in the key-auth plugin is set to `apikey`.
 
-| Provider property     | Env variable         | Default if not set    | Use                                                                             |
-|:----------------------|:---------------------|:----------------------|:--------------------------------------------------------------------------------|
-| kong_admin_uri        | KONG_ADMIN_ADDR      | http://localhost:8001 | The url of the kong admin api                                                   |
-| kong_admin_username   | KONG_ADMIN_USERNAME  | not set               | Username for the kong admin api                                                 |
-| kong_admin_password   | KONG_ADMIN_PASSWORD  | not set               | Password for the kong admin api                                                 |
-| tls_skip_verify       | TLS_SKIP_VERIFY      | false                 | Whether to skip tls certificate verification for the kong api when using https  |
-| kong_api_key          | KONG_API_KEY         | not set               | API key used to secure the kong admin API                                       |
-| kong_admin_token      | KONG_ADMIN_TOKEN     | not set               | API key used to secure the kong admin API in the Enterprise Edition             |
+| Provider property              | Env variable                  | Default if not set    | Use                                                                             |
+|:-------------------------------|:------------------------------|:----------------------|:--------------------------------------------------------------------------------|
+| kong_admin_uri                 | KONG_ADMIN_ADDR               | http://localhost:8001 | The url of the kong admin api                                                   |
+| kong_admin_username            | KONG_ADMIN_USERNAME           | not set               | Username for the kong admin api                                                 |
+| kong_admin_password            | KONG_ADMIN_PASSWORD           | not set               | Password for the kong admin api                                                 |
+| tls_skip_verify                | TLS_SKIP_VERIFY               | false                 | Whether to skip tls certificate verification for the kong api when using https  |
+| kong_api_key                   | KONG_API_KEY                  | not set               | API key used to secure the kong admin API                                       |
+| kong_admin_token               | KONG_ADMIN_TOKEN              | not set               | API key used to secure the kong admin API in the Enterprise Edition             |
+| strict_plugins_match           | STRICT_PLUGINS_MATCH          | false                 | Should plugins `config_json` field strictly match plugin configuration          |
 
 
 

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -8,5 +8,5 @@ builds:
       - windows
     goarch:
       - amd64
-archive:
-  format: zip
+archives:
+  - format: zip

--- a/kong/provider_test.go
+++ b/kong/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	terraformconfig "github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/kevholditch/gokong"
@@ -31,6 +32,36 @@ func TestProvider(t *testing.T) {
 
 func TestProvider_impl(t *testing.T) {
 	var _ terraform.ResourceProvider = Provider()
+}
+
+func TestProvider_configure(t *testing.T) {
+	c, err := terraformconfig.NewRawConfig(map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rc := terraform.NewResourceConfig(c)
+	p := Provider()
+	err = p.Configure(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestProvider_configure_strict(t *testing.T) {
+	c, err := terraformconfig.NewRawConfig(map[string]interface{}{
+		"strict_plugins_match": "true",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rc := terraform.NewResourceConfig(c)
+	p := Provider()
+	err = p.Configure(rc)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestMain(m *testing.M) {

--- a/kong/resource_kong_certificate.go
+++ b/kong/resource_kong_certificate.go
@@ -38,7 +38,7 @@ func resourceKongCertificateCreate(d *schema.ResourceData, meta interface{}) err
 
 	certificateRequest := createKongCertificateRequestFromResourceData(d)
 
-	certificate, err := meta.(*gokong.KongAdminClient).Certificates().Create(certificateRequest)
+	certificate, err := meta.(*config).adminClient.Certificates().Create(certificateRequest)
 
 	if err != nil {
 		return fmt.Errorf("failed to create kong certificate: %v error: %v", certificateRequest, err)
@@ -54,7 +54,7 @@ func resourceKongCertificateUpdate(d *schema.ResourceData, meta interface{}) err
 
 	certificateRequest := createKongCertificateRequestFromResourceData(d)
 
-	_, err := meta.(*gokong.KongAdminClient).Certificates().UpdateById(d.Id(), certificateRequest)
+	_, err := meta.(*config).adminClient.Certificates().UpdateById(d.Id(), certificateRequest)
 
 	if err != nil {
 		return fmt.Errorf("error updating kong certificate: %s", err)
@@ -65,7 +65,7 @@ func resourceKongCertificateUpdate(d *schema.ResourceData, meta interface{}) err
 
 func resourceKongCertificateRead(d *schema.ResourceData, meta interface{}) error {
 
-	certificate, err := meta.(*gokong.KongAdminClient).Certificates().GetById(d.Id())
+	certificate, err := meta.(*config).adminClient.Certificates().GetById(d.Id())
 
 	if err != nil {
 		return fmt.Errorf("could not find kong certificate: %v", err)
@@ -88,7 +88,7 @@ func resourceKongCertificateRead(d *schema.ResourceData, meta interface{}) error
 
 func resourceKongCertificateDelete(d *schema.ResourceData, meta interface{}) error {
 
-	err := meta.(*gokong.KongAdminClient).Certificates().DeleteById(d.Id())
+	err := meta.(*config).adminClient.Certificates().DeleteById(d.Id())
 
 	if err != nil {
 		return fmt.Errorf("could not delete kong certificate: %v", err)

--- a/kong/resource_kong_certificate_test.go
+++ b/kong/resource_kong_certificate_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/kevholditch/gokong"
 )
 
 func TestAccKongCertificate(t *testing.T) {
@@ -56,7 +55,7 @@ func TestAccKongCertificateImport(t *testing.T) {
 
 func testAccCheckKongCertificateDestroy(state *terraform.State) error {
 
-	client := testAccProvider.Meta().(*gokong.KongAdminClient)
+	client := testAccProvider.Meta().(*config).adminClient
 
 	certificates := getResourcesByType("kong_certificate", state)
 
@@ -90,7 +89,7 @@ func testAccCheckKongCertificateExists(resourceKey string) resource.TestCheckFun
 			return fmt.Errorf("no ID is set")
 		}
 
-		api, err := testAccProvider.Meta().(*gokong.KongAdminClient).Certificates().GetById(rs.Primary.ID)
+		api, err := testAccProvider.Meta().(*config).adminClient.Certificates().GetById(rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/kong/resource_kong_consumer.go
+++ b/kong/resource_kong_consumer.go
@@ -36,7 +36,7 @@ func resourceKongConsumerCreate(d *schema.ResourceData, meta interface{}) error 
 
 	consumerRequest := createKongConsumerRequestFromResourceData(d)
 
-	consumer, err := meta.(*gokong.KongAdminClient).Consumers().Create(consumerRequest)
+	consumer, err := meta.(*config).adminClient.Consumers().Create(consumerRequest)
 
 	if err != nil {
 		return fmt.Errorf("failed to create kong consumer: %v error: %v", consumerRequest, err)
@@ -52,7 +52,7 @@ func resourceKongConsumerUpdate(d *schema.ResourceData, meta interface{}) error 
 
 	consumerRequest := createKongConsumerRequestFromResourceData(d)
 
-	_, err := meta.(*gokong.KongAdminClient).Consumers().UpdateById(d.Id(), consumerRequest)
+	_, err := meta.(*config).adminClient.Consumers().UpdateById(d.Id(), consumerRequest)
 
 	if err != nil {
 		return fmt.Errorf("error updating kong consumer: %s", err)
@@ -64,7 +64,7 @@ func resourceKongConsumerUpdate(d *schema.ResourceData, meta interface{}) error 
 func resourceKongConsumerRead(d *schema.ResourceData, meta interface{}) error {
 
 	id := d.Id()
-	consumer, err := meta.(*gokong.KongAdminClient).Consumers().GetById(id)
+	consumer, err := meta.(*config).adminClient.Consumers().GetById(id)
 
 	if err != nil {
 		return fmt.Errorf("could not find kong consumer with id: %s error: %v", id, err)
@@ -82,7 +82,7 @@ func resourceKongConsumerRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceKongConsumerDelete(d *schema.ResourceData, meta interface{}) error {
 
-	err := meta.(*gokong.KongAdminClient).Consumers().DeleteById(d.Id())
+	err := meta.(*config).adminClient.Consumers().DeleteById(d.Id())
 
 	if err != nil {
 		return fmt.Errorf("could not delete kong consumer: %v", err)

--- a/kong/resource_kong_consumer_plugin_config.go
+++ b/kong/resource_kong_consumer_plugin_config.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/kevholditch/gokong"
 )
 
 func resourceKongConsumerPluginConfig() *schema.Resource {
@@ -111,9 +110,9 @@ func resourceKongConsumerPluginConfigCreate(d *schema.ResourceData, meta interfa
 
 	consumerId := readStringFromResource(d, "consumer_id")
 	pluginName := readStringFromResource(d, "plugin_name")
-	config := readStringFromResource(d, "config_json")
+	configJson := readStringFromResource(d, "config_json")
 
-	consumerPluginConfig, err := meta.(*gokong.KongAdminClient).Consumers().CreatePluginConfig(consumerId, pluginName, config)
+	consumerPluginConfig, err := meta.(*config).adminClient.Consumers().CreatePluginConfig(consumerId, pluginName, configJson)
 	if err != nil {
 		return fmt.Errorf("failed to create kong consumer plugin config, error: %v", err)
 	}
@@ -136,12 +135,12 @@ func resourceKongConsumerPluginConfigRead(d *schema.ResourceData, meta interface
 	}
 
 	// First check if the consumer exists. If it does not then the consumer plugin no longer exists either.
-	if consumer, _ := meta.(*gokong.KongAdminClient).Consumers().GetById(idFields.consumerId); consumer == nil {
+	if consumer, _ := meta.(*config).adminClient.Consumers().GetById(idFields.consumerId); consumer == nil {
 		d.SetId("")
 		return nil
 	}
 
-	consumerPluginConfig, err := meta.(*gokong.KongAdminClient).Consumers().GetPluginConfig(idFields.consumerId, idFields.pluginName, idFields.id)
+	consumerPluginConfig, err := meta.(*config).adminClient.Consumers().GetPluginConfig(idFields.consumerId, idFields.pluginName, idFields.id)
 
 	if err != nil {
 		return fmt.Errorf("could not find kong consumer plugin config with id: %s error: %v", d.Id(), err)
@@ -175,7 +174,7 @@ func resourceKongConsumerPluginConfigDelete(d *schema.ResourceData, meta interfa
 		return err
 	}
 
-	err = meta.(*gokong.KongAdminClient).Consumers().DeletePluginConfig(idFields.consumerId, idFields.pluginName, idFields.id)
+	err = meta.(*config).adminClient.Consumers().DeletePluginConfig(idFields.consumerId, idFields.pluginName, idFields.id)
 
 	if err != nil {
 		return fmt.Errorf("could not delete kong consumer plugin config: %v", err)

--- a/kong/resource_kong_consumer_plugin_config_test.go
+++ b/kong/resource_kong_consumer_plugin_config_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/kevholditch/gokong"
 )
 
 func TestAccKongConsumerPluginConfig(t *testing.T) {
@@ -80,7 +79,7 @@ func TestAccCheckKongConsumerPluginCreateAndRefreshFromNonExistentConsumer(t *te
 
 func testAccCheckKongConsumerPluginConfig(state *terraform.State) error {
 
-	client := testAccProvider.Meta().(*gokong.KongAdminClient)
+	client := testAccProvider.Meta().(*config).adminClient
 
 	consumerPluginConfigs := getResourcesByType("kong_consumer_plugin_config", state)
 
@@ -124,7 +123,7 @@ func testAccCheckKongConsumerPluginConfigExists(resourceKey string) resource.Tes
 			return fmt.Errorf("no ID is set")
 		}
 
-		client := testAccProvider.Meta().(*gokong.KongAdminClient)
+		client := testAccProvider.Meta().(*config).adminClient
 
 		idFields, err := splitIdIntoFields(rs.Primary.ID)
 
@@ -154,7 +153,7 @@ func deleteConsumer(resourceKey string) resource.TestCheckFunc {
 			return fmt.Errorf("not found: %s", resourceKey)
 		}
 
-		if err := testAccProvider.Meta().(*gokong.KongAdminClient).Consumers().DeleteById(rs.Primary.ID); err != nil {
+		if err := testAccProvider.Meta().(*config).adminClient.Consumers().DeleteById(rs.Primary.ID); err != nil {
 			return fmt.Errorf("could not delete kong consumer: %v", err)
 		}
 

--- a/kong/resource_kong_consumer_test.go
+++ b/kong/resource_kong_consumer_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/kevholditch/gokong"
 )
 
 func TestAccKongConsumer(t *testing.T) {
@@ -56,7 +55,7 @@ func TestAccKongConsumerImport(t *testing.T) {
 
 func testAccCheckKongConsumerDestroy(state *terraform.State) error {
 
-	client := testAccProvider.Meta().(*gokong.KongAdminClient)
+	client := testAccProvider.Meta().(*config).adminClient
 
 	consumers := getResourcesByType("kong_consumer", state)
 
@@ -90,7 +89,7 @@ func testAccCheckKongConsumerExists(resourceKey string) resource.TestCheckFunc {
 			return fmt.Errorf("no ID is set")
 		}
 
-		client := testAccProvider.Meta().(*gokong.KongAdminClient)
+		client := testAccProvider.Meta().(*config).adminClient
 
 		api, err := client.Consumers().GetById(rs.Primary.ID)
 

--- a/kong/resource_kong_plugin_strict_test.go
+++ b/kong/resource_kong_plugin_strict_test.go
@@ -1,0 +1,170 @@
+package kong
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccKongGlobalPluginStrict(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKongPluginDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCreateExplicitStrictGlobalPluginConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongPluginExists("kong_plugin.hmac_auth"),
+					resource.TestCheckResourceAttr("kong_plugin.hmac_auth", "name", "hmac-auth"),
+					resource.TestCheckResourceAttr("kong_plugin.hmac_auth", "enabled", "true"),
+				),
+			},
+			{
+				Config: testUpdateExplicitStrictGlobalPluginConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongPluginExists("kong_plugin.hmac_auth"),
+					resource.TestCheckResourceAttr("kong_plugin.hmac_auth", "name", "hmac-auth"),
+					resource.TestCheckResourceAttr("kong_plugin.hmac_auth", "enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKongGlobalPluginImplicitStrict(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKongPluginDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCreateImplicitStrictGlobalPluginConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongPluginExists("kong_plugin.hmac_auth"),
+					resource.TestCheckResourceAttr("kong_plugin.hmac_auth", "name", "hmac-auth"),
+					resource.TestCheckResourceAttr("kong_plugin.hmac_auth", "enabled", "true"),
+				),
+			},
+			{
+				Config: testUpdateImplicitStrictGlobalPluginConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongPluginExists("kong_plugin.hmac_auth"),
+					resource.TestCheckResourceAttr("kong_plugin.hmac_auth", "name", "hmac-auth"),
+					resource.TestCheckResourceAttr("kong_plugin.hmac_auth", "enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKongPluginImportConfigJsonStrict(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKongPluginDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCreateExplicitStrictGlobalPluginConfig,
+			},
+			{
+				ResourceName:      "kong_plugin.hmac_auth",
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+const testCreateExplicitStrictGlobalPluginConfig = `
+resource "kong_plugin" "hmac_auth" {
+	name  = "hmac-auth"
+	enabled = "true"
+    strict_match = true
+	config_json = <<EOT
+	{
+   	"algorithms": [
+   	    "hmac-sha1",
+   	    "hmac-sha256",
+   	    "hmac-sha384",
+   	    "hmac-sha512"
+   	],
+    "anonymous": null,
+   	"clock_skew": 300,
+   	"enforce_headers": [],
+   	"hide_credentials": true,
+   	"validate_request_body": false
+	}
+EOT
+}`
+
+const testCreateImplicitStrictGlobalPluginConfig = `
+provider "kong" {
+    strict_plugins_match = "true"
+}
+
+resource "kong_plugin" "hmac_auth" {
+	name  = "hmac-auth"
+	enabled = "true"
+	config_json = <<EOT
+	{
+   	"algorithms": [
+   	    "hmac-sha1",
+   	    "hmac-sha256",
+   	    "hmac-sha384",
+   	    "hmac-sha512"
+   	],
+    "anonymous": null,
+   	"clock_skew": 300,
+   	"enforce_headers": [],
+   	"hide_credentials": true,
+   	"validate_request_body": false
+	}
+EOT
+}`
+
+const testUpdateExplicitStrictGlobalPluginConfig = `
+resource "kong_plugin" "hmac_auth" {
+	name  = "hmac-auth"
+    strict_match = true
+	config_json = <<EOT
+	{
+   	"algorithms": [
+   	    "hmac-sha1",
+   	    "hmac-sha256",
+   	    "hmac-sha384",
+   	    "hmac-sha512"
+   	],
+    "anonymous": null,
+   	"clock_skew": 300,
+   	"enforce_headers": [],
+   	"hide_credentials": false,
+   	"validate_request_body": false
+	}
+EOT
+}`
+
+const testUpdateImplicitStrictGlobalPluginConfig = `
+provider "kong" {
+    strict_plugins_match = "true"
+}
+
+resource "kong_plugin" "hmac_auth" {
+	name  = "hmac-auth"
+	config_json = <<EOT
+	{
+   	"algorithms": [
+   	    "hmac-sha1",
+   	    "hmac-sha256",
+   	    "hmac-sha384",
+   	    "hmac-sha512"
+   	],
+    "anonymous": null,
+   	"clock_skew": 300,
+   	"enforce_headers": [],
+   	"hide_credentials": false,
+   	"validate_request_body": false
+	}
+EOT
+}
+`

--- a/kong/resource_kong_plugin_test.go
+++ b/kong/resource_kong_plugin_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/kevholditch/gokong"
 )
 
 func TestAccKongGlobalPlugin(t *testing.T) {
@@ -147,11 +146,10 @@ func TestAccKongPluginImportConfigJson(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckKongPluginDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testCreateGlobalPluginConfig,
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      "kong_plugin.hmac_auth",
 				ImportState:       true,
 				ImportStateVerify: false,
@@ -162,7 +160,7 @@ func TestAccKongPluginImportConfigJson(t *testing.T) {
 
 func testAccCheckKongPluginDestroy(state *terraform.State) error {
 
-	client := testAccProvider.Meta().(*gokong.KongAdminClient)
+	client := testAccProvider.Meta().(*config).adminClient
 
 	plugins := getResourcesByType("kong_plugin", state)
 
@@ -231,7 +229,7 @@ func testAccCheckKongPluginExists(resourceKey string) resource.TestCheckFunc {
 			return fmt.Errorf("no ID is set")
 		}
 
-		api, err := testAccProvider.Meta().(*gokong.KongAdminClient).Plugins().GetById(rs.Primary.ID)
+		api, err := testAccProvider.Meta().(*config).adminClient.Plugins().GetById(rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/kong/resource_kong_route.go
+++ b/kong/resource_kong_route.go
@@ -116,7 +116,7 @@ func resourceKongRouteCreate(d *schema.ResourceData, meta interface{}) error {
 
 	routeRequest := createKongRouteRequestFromResourceData(d)
 
-	route, err := meta.(*gokong.KongAdminClient).Routes().Create(routeRequest)
+	route, err := meta.(*config).adminClient.Routes().Create(routeRequest)
 	if err != nil {
 		return fmt.Errorf("failed to create kong route: %v error: %v", routeRequest, err)
 	}
@@ -131,7 +131,7 @@ func resourceKongRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	routeRequest := createKongRouteRequestFromResourceData(d)
 
-	_, err := meta.(*gokong.KongAdminClient).Routes().UpdateById(d.Id(), routeRequest)
+	_, err := meta.(*config).adminClient.Routes().UpdateById(d.Id(), routeRequest)
 
 	if err != nil {
 		return fmt.Errorf("error updating kong route: %s", err)
@@ -142,7 +142,7 @@ func resourceKongRouteUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceKongRouteRead(d *schema.ResourceData, meta interface{}) error {
 
-	route, err := meta.(*gokong.KongAdminClient).Routes().GetById(d.Id())
+	route, err := meta.(*config).adminClient.Routes().GetById(d.Id())
 
 	if err != nil {
 		return fmt.Errorf("could not find kong route: %v", err)
@@ -205,7 +205,7 @@ func resourceKongRouteRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceKongRouteDelete(d *schema.ResourceData, meta interface{}) error {
 
-	err := meta.(*gokong.KongAdminClient).Routes().DeleteById(d.Id())
+	err := meta.(*config).adminClient.Routes().DeleteById(d.Id())
 
 	if err != nil {
 		return fmt.Errorf("could not delete kong route: %v", err)

--- a/kong/resource_kong_route_test.go
+++ b/kong/resource_kong_route_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/kevholditch/gokong"
 )
 
 func TestAccKongRoute(t *testing.T) {
@@ -102,7 +101,7 @@ func TestAccKongRouteImport(t *testing.T) {
 
 func testAccCheckKongRouteDestroy(state *terraform.State) error {
 
-	client := testAccProvider.Meta().(*gokong.KongAdminClient)
+	client := testAccProvider.Meta().(*config).adminClient
 
 	routes := getResourcesByType("kong_route", state)
 
@@ -136,7 +135,7 @@ func testAccCheckKongRouteExists(resourceKey string) resource.TestCheckFunc {
 			return fmt.Errorf("no ID is set")
 		}
 
-		route, err := testAccProvider.Meta().(*gokong.KongAdminClient).Routes().GetById(rs.Primary.ID)
+		route, err := testAccProvider.Meta().(*config).adminClient.Routes().GetById(rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/kong/resource_kong_service.go
+++ b/kong/resource_kong_service.go
@@ -76,7 +76,7 @@ func resourceKongServiceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	serviceRequest := createKongServiceRequestFromResourceData(d)
 
-	service, err := meta.(*gokong.KongAdminClient).Services().Create(serviceRequest)
+	service, err := meta.(*config).adminClient.Services().Create(serviceRequest)
 	if err != nil {
 		return fmt.Errorf("failed to create kong service: %v error: %v", serviceRequest, err)
 	}
@@ -91,7 +91,7 @@ func resourceKongServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	serviceRequest := createKongServiceRequestFromResourceData(d)
 
-	_, err := meta.(*gokong.KongAdminClient).Services().UpdateServiceById(d.Id(), serviceRequest)
+	_, err := meta.(*config).adminClient.Services().UpdateServiceById(d.Id(), serviceRequest)
 
 	if err != nil {
 		return fmt.Errorf("error updating kong service: %s", err)
@@ -102,7 +102,7 @@ func resourceKongServiceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceKongServiceRead(d *schema.ResourceData, meta interface{}) error {
 
-	service, err := meta.(*gokong.KongAdminClient).Services().GetServiceById(d.Id())
+	service, err := meta.(*config).adminClient.Services().GetServiceById(d.Id())
 
 	if err != nil {
 		return fmt.Errorf("could not find kong service: %v", err)
@@ -153,7 +153,7 @@ func resourceKongServiceRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceKongServiceDelete(d *schema.ResourceData, meta interface{}) error {
 
-	err := meta.(*gokong.KongAdminClient).Services().DeleteServiceById(d.Id())
+	err := meta.(*config).adminClient.Services().DeleteServiceById(d.Id())
 
 	if err != nil {
 		return fmt.Errorf("could not delete kong service: %v", err)

--- a/kong/resource_kong_service_test.go
+++ b/kong/resource_kong_service_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/kevholditch/gokong"
 )
 
 func TestAccKongService(t *testing.T) {
@@ -89,7 +88,7 @@ func TestAccKongServiceImport(t *testing.T) {
 
 func testAccCheckKongServiceDestroy(state *terraform.State) error {
 
-	client := testAccProvider.Meta().(*gokong.KongAdminClient)
+	client := testAccProvider.Meta().(*config).adminClient
 
 	services := getResourcesByType("kong_service", state)
 
@@ -123,7 +122,7 @@ func testAccCheckKongServiceExists(resourceKey string) resource.TestCheckFunc {
 			return fmt.Errorf("no ID is set")
 		}
 
-		service, err := testAccProvider.Meta().(*gokong.KongAdminClient).Services().GetServiceById(rs.Primary.ID)
+		service, err := testAccProvider.Meta().(*config).adminClient.Services().GetServiceById(rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/kong/resource_kong_sni.go
+++ b/kong/resource_kong_sni.go
@@ -35,7 +35,7 @@ func resourceKongSniCreate(d *schema.ResourceData, meta interface{}) error {
 
 	sniRequest := createKongSniRequestFromResourceData(d)
 
-	sni, err := meta.(*gokong.KongAdminClient).Snis().Create(sniRequest)
+	sni, err := meta.(*config).adminClient.Snis().Create(sniRequest)
 
 	if err != nil {
 		return fmt.Errorf("failed to create kong sni: %v error: %v", sniRequest, err)
@@ -48,7 +48,7 @@ func resourceKongSniCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceKongSniRead(d *schema.ResourceData, meta interface{}) error {
 
-	sni, err := meta.(*gokong.KongAdminClient).Snis().GetByName(d.Id())
+	sni, err := meta.(*config).adminClient.Snis().GetByName(d.Id())
 
 	if err != nil {
 		return fmt.Errorf("could not find kong sni: %v", err)
@@ -66,7 +66,7 @@ func resourceKongSniRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceKongSniDelete(d *schema.ResourceData, meta interface{}) error {
 
-	err := meta.(*gokong.KongAdminClient).Snis().DeleteByName(d.Id())
+	err := meta.(*config).adminClient.Snis().DeleteByName(d.Id())
 
 	if err != nil {
 		return fmt.Errorf("could not delete kong sni: %v", err)

--- a/kong/resource_kong_sni_test.go
+++ b/kong/resource_kong_sni_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/kevholditch/gokong"
 )
 
 func TestAccKongSni(t *testing.T) {
@@ -54,7 +53,7 @@ func TestAccKongSniImport(t *testing.T) {
 
 func testAccCheckKongSniDestroy(state *terraform.State) error {
 
-	client := testAccProvider.Meta().(*gokong.KongAdminClient)
+	client := testAccProvider.Meta().(*config).adminClient
 
 	snis := getResourcesByType("kong_sni", state)
 
@@ -88,7 +87,7 @@ func testAccCheckKongSniExists(resourceKey string) resource.TestCheckFunc {
 			return fmt.Errorf("no ID is set")
 		}
 
-		api, err := testAccProvider.Meta().(*gokong.KongAdminClient).Snis().GetByName(rs.Primary.ID)
+		api, err := testAccProvider.Meta().(*config).adminClient.Snis().GetByName(rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/kong/resource_kong_target.go
+++ b/kong/resource_kong_target.go
@@ -41,7 +41,7 @@ func resourceKongTargetCreate(d *schema.ResourceData, meta interface{}) error {
 
 	targetRequest := createKongTargetRequestFromResourceData(d)
 
-	target, err := meta.(*gokong.KongAdminClient).Targets().CreateFromUpstreamId(readStringFromResource(d, "upstream_id"), targetRequest)
+	target, err := meta.(*config).adminClient.Targets().CreateFromUpstreamId(readStringFromResource(d, "upstream_id"), targetRequest)
 
 	if err != nil {
 		return fmt.Errorf("failed to create kong target: %v error: %v", targetRequest, err)
@@ -57,12 +57,12 @@ func resourceKongTargetRead(d *schema.ResourceData, meta interface{}) error {
 	var ids = strings.Split(d.Id(), "/")
 
 	// First check if the upstream exists. If it does not then the target no longer exists either.
-	if upstream, _ := meta.(*gokong.KongAdminClient).Upstreams().GetById(ids[0]); upstream == nil {
+	if upstream, _ := meta.(*config).adminClient.Upstreams().GetById(ids[0]); upstream == nil {
 		d.SetId("")
 		return nil
 	}
 
-	targets, err := meta.(*gokong.KongAdminClient).Targets().GetTargetsFromUpstreamId(ids[0])
+	targets, err := meta.(*config).adminClient.Targets().GetTargetsFromUpstreamId(ids[0])
 
 	if err != nil {
 		return fmt.Errorf("could not find kong target: %v", err)
@@ -86,7 +86,7 @@ func resourceKongTargetRead(d *schema.ResourceData, meta interface{}) error {
 func resourceKongTargetDelete(d *schema.ResourceData, meta interface{}) error {
 
 	var ids = strings.Split(d.Id(), "/")
-	if err := meta.(*gokong.KongAdminClient).Targets().DeleteFromUpstreamById(ids[0], ids[1]); err != nil {
+	if err := meta.(*config).adminClient.Targets().DeleteFromUpstreamById(ids[0], ids[1]); err != nil {
 		return fmt.Errorf("could not delete kong target: %v", err)
 	}
 

--- a/kong/resource_kong_target_test.go
+++ b/kong/resource_kong_target_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/kevholditch/gokong"
 )
 
 func TestAccKongTarget(t *testing.T) {
@@ -101,7 +100,7 @@ func TestAccKongTargetImport(t *testing.T) {
 
 func testAccCheckKongTargetDestroy(state *terraform.State) error {
 
-	client := testAccProvider.Meta().(*gokong.KongAdminClient)
+	client := testAccProvider.Meta().(*config).adminClient
 
 	targets := getResourcesByType("kong_target", state)
 
@@ -140,7 +139,7 @@ func testAccCheckKongTargetExists(resourceKey string) resource.TestCheckFunc {
 		}
 
 		var ids = strings.Split(rs.Primary.ID, "/")
-		api, err := testAccProvider.Meta().(*gokong.KongAdminClient).Targets().GetTargetsFromUpstreamId(ids[0])
+		api, err := testAccProvider.Meta().(*config).adminClient.Targets().GetTargetsFromUpstreamId(ids[0])
 
 		if err != nil {
 			return err
@@ -180,7 +179,7 @@ func testAccCheckKongTargetDoesNotExist(targetResourceKey string, upstreamResour
 			return fmt.Errorf("no upstream ID is set")
 		}
 
-		targets, err := testAccProvider.Meta().(*gokong.KongAdminClient).Targets().GetTargetsFromUpstreamId(rs.Primary.ID)
+		targets, err := testAccProvider.Meta().(*config).adminClient.Targets().GetTargetsFromUpstreamId(rs.Primary.ID)
 
 		if len(targets) > 0 {
 			return fmt.Errorf("expecting zero target resources found %v", len(targets))
@@ -202,7 +201,7 @@ func deleteUpstream(upstreamResourceKey string) resource.TestCheckFunc {
 			return fmt.Errorf("not found: %s", upstreamResourceKey)
 		}
 
-		if err := testAccProvider.Meta().(*gokong.KongAdminClient).Upstreams().DeleteById(rs.Primary.ID); err != nil {
+		if err := testAccProvider.Meta().(*config).adminClient.Upstreams().DeleteById(rs.Primary.ID); err != nil {
 			return fmt.Errorf("could not delete kong upstream: %v", err)
 		}
 

--- a/kong/resource_kong_upstream.go
+++ b/kong/resource_kong_upstream.go
@@ -254,7 +254,7 @@ func resourceKongUpstreamCreate(d *schema.ResourceData, meta interface{}) error 
 
 	upstreamRequest := createKongUpstreamRequestFromResourceData(d)
 
-	upstream, err := meta.(*gokong.KongAdminClient).Upstreams().Create(upstreamRequest)
+	upstream, err := meta.(*config).adminClient.Upstreams().Create(upstreamRequest)
 
 	if err != nil {
 		return fmt.Errorf("failed to create kong upstream: %v error: %v", upstreamRequest, err)
@@ -270,7 +270,7 @@ func resourceKongUpstreamUpdate(d *schema.ResourceData, meta interface{}) error 
 
 	upstreamRequest := createKongUpstreamRequestFromResourceData(d)
 
-	_, err := meta.(*gokong.KongAdminClient).Upstreams().UpdateById(d.Id(), upstreamRequest)
+	_, err := meta.(*config).adminClient.Upstreams().UpdateById(d.Id(), upstreamRequest)
 
 	if err != nil {
 		return fmt.Errorf("error updating kong upstream: %s", err)
@@ -281,7 +281,7 @@ func resourceKongUpstreamUpdate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceKongUpstreamRead(d *schema.ResourceData, meta interface{}) error {
 
-	upstream, err := meta.(*gokong.KongAdminClient).Upstreams().GetById(d.Id())
+	upstream, err := meta.(*config).adminClient.Upstreams().GetById(d.Id())
 
 	if err != nil {
 		return fmt.Errorf("could not find kong upstream: %v", err)
@@ -308,7 +308,7 @@ func resourceKongUpstreamRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceKongUpstreamDelete(d *schema.ResourceData, meta interface{}) error {
 
-	err := meta.(*gokong.KongAdminClient).Upstreams().DeleteById(d.Id())
+	err := meta.(*config).adminClient.Upstreams().DeleteById(d.Id())
 
 	if err != nil {
 		return fmt.Errorf("could not delete kong upstream: %v", err)

--- a/kong/resource_kong_upstream_test.go
+++ b/kong/resource_kong_upstream_test.go
@@ -147,7 +147,7 @@ func TestAccKongUpstreamImport(t *testing.T) {
 
 func testAccCheckKongUpstreamDestroy(state *terraform.State) error {
 
-	client := testAccProvider.Meta().(*gokong.KongAdminClient)
+	client := testAccProvider.Meta().(*config).adminClient
 
 	upstreams := getResourcesByType("kong_upstream", state)
 
@@ -181,7 +181,7 @@ func testAccCheckKongUpstreamExists(resourceKey string) resource.TestCheckFunc {
 			return fmt.Errorf("no ID is set")
 		}
 
-		api, err := testAccProvider.Meta().(*gokong.KongAdminClient).Upstreams().GetById(rs.Primary.ID)
+		api, err := testAccProvider.Meta().(*config).adminClient.Upstreams().GetById(rs.Primary.ID)
 
 		if err != nil {
 			return err


### PR DESCRIPTION
Currently, this Kong provider is not comparing plugins configuration from Terraform file with a configuration in the Kong server. When someone change configuration in Terraform the provider will update a plugin in the Kong. But when someone would manually change plugin configuration the change is not discovered.

This behaviour allows easily import plugin to Terraform. But in a case when you want full control over the plugin state it would be better to track plugin state in the Kong.

I've added two things. First one is the `strict_match` property for  `kong_plugin`. This allows strict plugin configuration matching and it can be enabled per plugin. The second one is the `strict_plugins_match` property for the Kong provider. It enables strict matching for all plugins.

1. I know that the parameter names are not perfect, but I'm open to change it.
2. I was trying to adjust also `kong_consumer_plugin_config` resource, but I've no idea what is the difference with `kong_plugin` resource.

PS. Would it be possible to create a branch for Terraform 0.11.x? 