### PR TITLE
Use GetOkExists for reading pointer types

### DIFF
--- a/kong/resource_kong_service_test.go
+++ b/kong/resource_kong_service_test.go
@@ -45,6 +45,27 @@ func TestAccKongService(t *testing.T) {
 			},
 		},
 	})
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKongServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCreateServiceConfigZero,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongServiceExists("kong_service.service"),
+					resource.TestCheckResourceAttr("kong_service.service", "retries", "0"),
+				),
+			},
+			{
+				Config: testUpdateServiceConfigZero,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongServiceExists("kong_service.service"),
+					resource.TestCheckResourceAttr("kong_service.service", "retries", "0"),
+				),
+			},
+		},
+	})
 }
 
 func TestAccKongServiceImport(t *testing.T) {
@@ -139,6 +160,31 @@ resource "kong_service" "service" {
 	connect_timeout = 6000
 	write_timeout 	= 5000
 	read_timeout  	= 4000
+}
+`
+const testCreateServiceConfigZero = `
+resource "kong_service" "service" {
+	name     		= "test"
+	protocol 		= "http"
+	host     		= "test.org"
+	path     		= "/mypath"
+	retries  		= 0
+	connect_timeout = 1000
+	write_timeout 	= 2000
+	read_timeout  	= 3000
+}
+`
+const testUpdateServiceConfigZero = `
+resource "kong_service" "service" {
+	name     		= "test2"
+	protocol 		= "https"
+	host     		= "test2.org"
+	port     		= 8081
+	path     		= "/"
+	connect_timeout = 6000
+	write_timeout 	= 5000
+	read_timeout  	= 4000
+	retries         = 0
 }
 `
 const testImportServiceConfig = `

--- a/kong/resource_reader.go
+++ b/kong/resource_reader.go
@@ -67,7 +67,7 @@ func readIdPtrFromResource(d *schema.ResourceData, key string) *gokong.Id {
 }
 
 func readStringPtrFromResource(d *schema.ResourceData, key string) *string {
-	if value, ok := d.GetOk(key); ok {
+	if value, ok := d.GetOkExists(key); ok {
 		return gokong.String(value.(string))
 	}
 	return nil
@@ -85,8 +85,7 @@ func readIntFromResource(d *schema.ResourceData, key string) int {
 }
 
 func readIntPtrFromResource(d *schema.ResourceData, key string) *int {
-	value, ok := d.GetOk(key)
-	if ok {
+	if value, ok := d.GetOkExists(key); ok {
 		return gokong.Int(value.(int))
 	}
 	return nil


### PR DESCRIPTION
This PR addresses https://github.com/kevholditch/terraform-provider-kong/issues/93

Ultimately, the cause behind `terraform-provider-kong` not being willing to set `retries` to 0 appears to be some oddities with the upstream Terraform schema code. When we construct the payload for an update to a Kong service: https://github.com/kevholditch/terraform-provider-kong/blob/028fd63c145df185f24bce77f83a292e06fcd0f4/kong/resource_kong_service.go#L165-L177

The `readIntPtrFromResource(d, "retries")` returns `nil` when the value is `0`. The struct type `ServiceRequest` ([definition](https://github.com/kevholditch/gokong/blob/305470f01f9a2e2d049b718796716825369d4469/services.go#L12-L23)) sets `json:"omitempty"` on the `retries` field, which means that it gets dropped in this case.

The reason `readIntPtrFromResource` behaves this way is that it uses Terraform's `GetOk` https://github.com/kevholditch/terraform-provider-kong/blob/028fd63c145df185f24bce77f83a292e06fcd0f4/kong/resource_reader.go#L87-L93

`GetOk` has some somewhat surprising semantics ([source](https://github.com/hashicorp/terraform/blob/f1237f816c5d00c59648d3170c7b8f4afe6d982d/helper/schema/resource_data.go#L88-L109)). From its comments, "`GetOk` returns the data for the given key and whether or not the key has been set to a non-zero value at some point." When the value is the "zero" (for the given type), it treats it as if the value were not set.

`GetOkExists` ([source](https://github.com/hashicorp/terraform/blob/f1237f816c5d00c59648d3170c7b8f4afe6d982d/helper/schema/resource_data.go#L111-L125)) has the semantics we want here, though its comments appear to contradict its actual implementation (its comments start with the same sentence, but it _does not_ check if it is the zero value in reality. I'm going to file an upstream issue about the discrepancy). In this PR I changed the implementation of `readIntPtrFromResource` (and the similar `readStringPtrFromResource`) to use `GetOkExists` instead of `GetOk`.

I've left the other `readXYZ` functions alone, because their "zero" values are either the same as what they're returning now when their values are zero, or (in the case of `readIdPtrFromResource`) returning the zero value is actually incorrect (an empty string isn't a valid ID).

## Testing

I've added a test that checks if you can set `retries` to 0 that fails before my patch, and passes afterwards. I've also compiled the plugin and verified that when using a build based on my branch, I am able to set `retries` to 0 as expected.