### PR TITLE
Fix consumer creation with missing properties

### DIFF
--- a/kong/resource_kong_consumer.go
+++ b/kong/resource_kong_consumer.go
@@ -43,8 +43,8 @@ func resourceKongConsumer() *schema.Resource {
 func resourceKongConsumerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	consumerRequest := &kong.Consumer{
-		Username: kong.String(d.Get("username").(string)),
-		CustomID: kong.String(d.Get("custom_id").(string)),
+		Username: NilString(d.Get("username").(string)),
+		CustomID: NilString(d.Get("custom_id").(string)),
 		Tags:     readStringArrayPtrFromResource(d, "tags"),
 	}
 

--- a/kong/resource_kong_consumer_test.go
+++ b/kong/resource_kong_consumer_test.go
@@ -41,6 +41,26 @@ func TestAccKongConsumer(t *testing.T) {
 	})
 }
 
+func TestAccKongConsumerNilIDs(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKongConsumerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCreateConsumerConfigNoCustomID,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKongConsumerExists("kong_consumer.consumer"),
+					resource.TestCheckResourceAttr("kong_consumer.consumer", "username", "User3"),
+					resource.TestCheckResourceAttr("kong_consumer.consumer", "custom_id", ""),
+					resource.TestCheckResourceAttr("kong_consumer.consumer", "tags.#", "1"),
+					resource.TestCheckResourceAttr("kong_consumer.consumer", "tags.0", "c"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKongConsumerImport(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
@@ -124,5 +144,11 @@ resource "kong_consumer" "consumer" {
 	username  = "User2"
 	custom_id = "456"
     tags      = ["a"] 
+}
+`
+const testCreateConsumerConfigNoCustomID = `
+resource "kong_consumer" "consumer" {
+	username = "User3"
+	tags     = ["c"]
 }
 `

--- a/kong/utils.go
+++ b/kong/utils.go
@@ -154,3 +154,13 @@ func IDToString(v *string) string {
 	}
 	return *v
 }
+
+// NilString converts a string to a string pointer,
+// or if empty returns nil.
+func NilString(str string) *string {
+	if str == "" {
+		return nil
+	} else {
+		return kong.String(str)
+	}
+}


### PR DESCRIPTION
Previously the `username` or `custom_id` properties being absent would cause an error from Kong, because the properties would be sent as empty strings instead of being absent or `null`.

This partially fixes #137.  To completely fix it we also need to apply the same change to the `resourceKongConsumerUpdate` function, but currently that doesn't have the desired effect due to https://github.com/Kong/go-kong/issues/94.  Once a fix for https://github.com/Kong/go-kong/issues/94 is available in `go-kong` we can update to this version and complete the fix here.

Alternatively we could fork `go-kong`, implement a fix, and update this repo to refer to the fork - @kevholditch let me know if you'd like me to do this or submit the update fix in a later PR.