### PR TITLE
Fix re-creating a missing target on an upstream having multiple ones

### DIFF
--- a/kong/resource_kong_target.go
+++ b/kong/resource_kong_target.go
@@ -80,11 +80,13 @@ func resourceKongTargetRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(fmt.Errorf("could not find kong target: %v", err))
 	}
 
-	if targets == nil {
-		d.SetId("")
-	} else {
+	var recreate = true
+
+	if targets != nil {
 		for _, element := range targets {
 			if *element.ID == ids[1] {
+				recreate = false
+
 				err := d.Set("target", element.Target)
 				if err != nil {
 					return diag.FromErr(err)
@@ -103,6 +105,10 @@ func resourceKongTargetRead(ctx context.Context, d *schema.ResourceData, meta in
 				}
 			}
 		}
+	}
+
+	if recreate {
+		d.SetId("")
 	}
 
 	return diags

--- a/kong/resource_kong_target_test.go
+++ b/kong/resource_kong_target_test.go
@@ -205,7 +205,7 @@ func testAccCheckKongTargetExists(resourceKey string) resource.TestCheckFunc {
 			}
 		}
 
-		if ! targetFound {
+		if !targetFound {
 			return fmt.Errorf("target with id %v not found", rs.Primary.ID)
 		}
 
@@ -282,7 +282,7 @@ func testAccDeleteExistingKongTarget(resourceKey string) resource.TestCheckFunc 
 			}
 		}
 
-		if ! targetFound {
+		if !targetFound {
 			return fmt.Errorf("target with id %v not found", rs.Primary.ID)
 		}
 


### PR DESCRIPTION
Fixes the use case where an upstream has multiple targets and one target gets deleted while it still exists as a kong_target resource.
The target failed to be re-created prior to the fix.
Also, target tests have been updated to include 2 targets instead of a unique one.