### PR TITLE
Update readme with Kong v1 supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Kong Terraform Provider tested against real Kong!
 
 IMPORTANT
 ------
-The provider has been updated to support Kong `v2.X`, there were some breaking changes made between Kong `v1` and `v2`.  To use Kong `v1` use provider version `v6.X.X`.  That version will no longer be maintained.
+The provider has been updated to support Kong `v2.X`, there were some breaking changes made between Kong `v1` and `v2`.  To use Kong `v1` use provider version `v6.0.X`.  That version will no longer be maintained.
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Kong Terraform Provider tested against real Kong!
 
 IMPORTANT
 ------
-The provider has been updated to support Kong `v2.X`, there were some breaking changes made between Kong `v1` and `v2`.  To use Kong `v1` use provider version `v6.0.X`.  That version will no longer be maintained.
+The provider has been updated to support Kong `v2.X`, there were some breaking changes made between Kong `v1` and `v2`.  To use Kong `v1` use provider version `v6.1.1` or below.  That version will no longer be maintained.
 
 Requirements
 ------------


### PR DESCRIPTION
# Changelog

* Update `readme.md` with provider supported versions for Kong v1


# Notes

* Provider version `6.1.1` is the latest version that worked for me to create routes in Kong v1, so I thought of updating the docs 😄 