### PR TITLE
Bugfix consumer rsa public key must be nullable

### DIFF
--- a/kong/resource_kong_consumer_jwt_auth.go
+++ b/kong/resource_kong_consumer_jwt_auth.go
@@ -59,10 +59,10 @@ func resourceKongConsumerJWTAuth() *schema.Resource {
 func resourceKongConsumerJWTAuthCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	JWTAuthRequest := &kong.JWTAuth{
-		Algorithm:    kong.String(d.Get("algorithm").(string)),
-		Key:          kong.String(d.Get("key").(string)),
+		Algorithm:    readStringPtrFromResource(d, "algorithm"),
+		Key:          readStringPtrFromResource(d, "key"),
 		RSAPublicKey: readStringPtrFromResource(d, "rsa_public_key"),
-		Secret:       kong.String(d.Get("secret").(string)),
+		Secret:       readStringPtrFromResource(d, "secret"),
 		Tags:         readStringArrayPtrFromResource(d, "tags"),
 	}
 

--- a/kong/resource_kong_consumer_jwt_auth.go
+++ b/kong/resource_kong_consumer_jwt_auth.go
@@ -3,10 +3,11 @@ package kong
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/kong/go-kong/kong"
-	"strings"
 )
 
 func resourceKongConsumerJWTAuth() *schema.Resource {
@@ -37,7 +38,7 @@ func resourceKongConsumerJWTAuth() *schema.Resource {
 			},
 			"rsa_public_key": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: false,
 			},
 			"secret": {

--- a/kong/resource_kong_consumer_jwt_auth.go
+++ b/kong/resource_kong_consumer_jwt_auth.go
@@ -61,7 +61,7 @@ func resourceKongConsumerJWTAuthCreate(ctx context.Context, d *schema.ResourceDa
 	JWTAuthRequest := &kong.JWTAuth{
 		Algorithm:    kong.String(d.Get("algorithm").(string)),
 		Key:          kong.String(d.Get("key").(string)),
-		RSAPublicKey: kong.String(d.Get("rsa_public_key").(string)),
+		RSAPublicKey: readStringPtrFromResource(d, "rsa_public_key"),
 		Secret:       kong.String(d.Get("secret").(string)),
 		Tags:         readStringArrayPtrFromResource(d, "tags"),
 	}

--- a/kong/resource_kong_consumer_jwt_auth_test.go
+++ b/kong/resource_kong_consumer_jwt_auth_test.go
@@ -45,14 +45,14 @@ func TestAccJWTAuth(t *testing.T) {
 			{
 				Config: testCreateJWTAuthConfigRsaPublicKeyNull,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckJWTAuthExists("kong_consumer_jwt_auth.consumer_jwt_config"),
-					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config", "algorithm", "HS256"),
-					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config", "key", "my_key"),
-					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config", "secret", "my_secret"),
-					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config", "rsa_public_key", ""),
-					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config", "tags.#", "2"),
-					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config", "tags.0", "foo"),
-					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config", "tags.1", "bar"),
+					testAccCheckJWTAuthExists("kong_consumer_jwt_auth.consumer_jwt_config2"),
+					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config2", "algorithm", "HS256"),
+					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config2", "key", "my_key"),
+					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config2", "secret", "my_secret"),
+					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config2", "rsa_public_key", ""),
+					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config2", "tags.#", "2"),
+					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config2", "tags.0", "foo"),
+					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config2", "tags.1", "bar"),
 				),
 			},
 		},
@@ -180,22 +180,13 @@ resource "kong_consumer_jwt_auth" "consumer_jwt_config" {
 }
 `
 const testCreateJWTAuthConfigRsaPublicKeyNull = `
-resource "kong_consumer" "my_consumer" {
+resource "kong_consumer" "my_consumer2" {
 	username  = "User2"
 	custom_id = "456"
 }
 
-resource "kong_plugin" "jwt_plugin" {
-	name        = "jwt2"
-	config_json = <<EOT
-	{
-		"claims_to_verify": ["exp"]
-	}
-EOT
-}
-
-resource "kong_consumer_jwt_auth" "consumer_jwt_config" {
-	consumer_id    = "${kong_consumer.my_consumer.id}"
+resource "kong_consumer_jwt_auth" "consumer_jwt_config2" {
+	consumer_id    = "${kong_consumer.my_consumer2.id}"
 	algorithm      = "HS256"
 	key            = "my_key"
 	secret         = "my_secret"

--- a/kong/resource_kong_consumer_jwt_auth_test.go
+++ b/kong/resource_kong_consumer_jwt_auth_test.go
@@ -3,6 +3,7 @@ package kong
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/kong/go-kong/kong"
@@ -43,17 +44,16 @@ func TestAccJWTAuth(t *testing.T) {
 				),
 			},
 			{
-				Config: testCreateJWTAuthConfigRsaPublicKeyNull,
+				Config: testCreateJWTAuthConfigDefaults,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckJWTAuthExists("kong_consumer_jwt_auth.consumer_jwt_config2"),
-					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config2", "algorithm", "HS256"),
-					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config2", "key", "my_key"),
-					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config2", "secret", "my_secret"),
-					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config2", "rsa_public_key", ""),
-					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config2", "tags.#", "2"),
-					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config2", "tags.0", "foo"),
-					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config2", "tags.1", "bar"),
+					testAccCheckJWTAuthExists("kong_consumer_jwt_auth.consumer_jwt_config_defaults"),
+					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config_defaults", "algorithm", "HS256"),
+					resource.TestMatchResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config_defaults", "key", regexp.MustCompile(".+")),
+					resource.TestMatchResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config_defaults", "secret", regexp.MustCompile(".+")),
+					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config_defaults", "rsa_public_key", ""),
+					resource.TestCheckResourceAttr("kong_consumer_jwt_auth.consumer_jwt_config_defaults", "tags.#", "0"),
 				),
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -179,17 +179,13 @@ resource "kong_consumer_jwt_auth" "consumer_jwt_config" {
 	tags           = ["foo"]
 }
 `
-const testCreateJWTAuthConfigRsaPublicKeyNull = `
-resource "kong_consumer" "my_consumer2" {
-	username  = "User2"
-	custom_id = "456"
+const testCreateJWTAuthConfigDefaults = `
+resource "kong_consumer" "consumer_jwt_defaults" {
+	username  = "consumer_jwt"
+	custom_id = "666"
 }
 
-resource "kong_consumer_jwt_auth" "consumer_jwt_config2" {
-	consumer_id    = "${kong_consumer.my_consumer2.id}"
-	algorithm      = "HS256"
-	key            = "my_key"
-	secret         = "my_secret"
-  tags           = ["foo", "bar"]
+resource "kong_consumer_jwt_auth" "consumer_jwt_config_defaults" {
+	consumer_id    = "${kong_consumer.consumer_jwt_defaults.id}"
 }
 `


### PR DESCRIPTION
I need to create a `kong_consumer_jwt_auth` without `rsa_public_key`, only using a `secret`. With the currently implementation isn't possible to do that (this is a blocker bug).

According to the kong documentation https://docs.konghq.com/hub/kong-inc/jwt/#create-a-jwt-credential the `rsa_public_key` is **optional**.

This PR fix it, assuming the kong optional attributes:
- `key`
- `algorithm`
- `secret`
- `rsa_public_key`

The unit test `TestAccJWTAuth` was adapted to test the defaults for them.