### PR TITLE
Make `kong_consumer_key_auth` Resource Improbable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,11 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
-        env:
+        uses: crazy-max/ghaction-import-gpg@v6.1.0
+        with:
           # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.5.0

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,6 +28,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: '386'
+      - goos: windows
+        goarch: 'arm64'
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip
@@ -47,7 +49,7 @@ signs:
       - "${signature}"
       - "--detach-sign"
       - "${artifact}"
-release:
+# release:
 # If you want to manually examine the release before its live, uncomment this line:
 # draft: true
 changelog:

--- a/kong/resource_kong_consumer_key_auth.go
+++ b/kong/resource_kong_consumer_key_auth.go
@@ -15,6 +15,9 @@ func resourceKongConsumerKeyAuth() *schema.Resource {
 		ReadContext:   resourceKongConsumerKeyAuthRead,
 		DeleteContext: resourceKongConsumerKeyAuthDelete,
 		UpdateContext: resourceKongConsumerKeyAuthUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"consumer_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
We need this as part of Terraform upgrade and resource migration for our organization.
This change has been published and the import has been verified to be working using that.